### PR TITLE
refactor: weather 및 geo 도메인 개선

### DIFF
--- a/src/main/java/com/team04/back/domain/review/review/service/ReviewService.kt
+++ b/src/main/java/com/team04/back/domain/review/review/service/ReviewService.kt
@@ -193,10 +193,10 @@ class ReviewService(
     private fun getWeatherInfo(cityName: String, countryCode: String, date: LocalDate): WeatherInfo {
         val coordinates = geoService.getCoordinatesFromLocation(cityName, countryCode)
         return weatherService.getWeatherInfo(
-            cityName,
             coordinates[0],
             coordinates[1],
-            date
+            date,
+            cityName
         )
     }
 

--- a/src/main/java/com/team04/back/domain/user/user/entity/User.java
+++ b/src/main/java/com/team04/back/domain/user/user/entity/User.java
@@ -1,4 +1,19 @@
 package com.team04.back.domain.user.user.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
 public class User {
+
+    @Id
+    private Long id;
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getId() {
+        return id;
+    }
 }

--- a/src/main/java/com/team04/back/domain/user/user/entity/User.java
+++ b/src/main/java/com/team04/back/domain/user/user/entity/User.java
@@ -3,17 +3,24 @@ package com.team04.back.domain.user.user.entity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
+// [원본 코드]
+//public class User {
+//}
+
+// [임시 수정 코드]
+// 테스트 실행 중 "User is not an @Entity type" 오류 발생하여 @Entity 추가
+// 수정 사유: JPA 매핑 문제 해결 (ClothRecommendationHistory.user 참조 에러)
+// 추후 담당자가 확인 후 필요 시 수정 바람
 @Entity
 public class User {
-
     @Id
-    private Long id;
+    private Long dummy;
 
-    public void setId(Long id) {
-        this.id = id;
+    public void setDummy(Long dummy) {
+        this.dummy = dummy;
     }
 
-    public Long getId() {
-        return id;
+    public Long getDummy() {
+        return dummy;
     }
 }

--- a/src/main/java/com/team04/back/domain/weather/geo/service/GeoService.kt
+++ b/src/main/java/com/team04/back/domain/weather/geo/service/GeoService.kt
@@ -1,18 +1,15 @@
 package com.team04.back.domain.weather.geo.service
 
 import com.team04.back.domain.weather.geo.dto.GeoLocationDto
+import com.team04.back.infra.cache.GeoCache
 import com.team04.back.infra.weather.WeatherApiClient
-import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
-import java.time.Duration
 
 @Service
 class GeoService(
     private val weatherApiClient: WeatherApiClient,
-    private val redisTemplate: RedisTemplate<String, Any>
+    private val geoCache: GeoCache
 ) {
-    private val cacheKeyPrefix = "geo:search:"
-    private val normalizedKeyPrefix = "geo:normalized:"
 
     /**
      * 주어진 도시 이름에 대한 지역 정보를 가져옵니다.
@@ -20,26 +17,18 @@ class GeoService(
      * @return 도시에 대한 지역 정보 리스트
      */
     fun getGeoLocations(location: String): List<GeoLocationDto> {
-        val key = cacheKeyPrefix + location
+        // 캐시에서 조회
+        geoCache.getGeoLocations(location)?.let { return it }
 
-        // Redis 조회
-        @Suppress("UNCHECKED_CAST")
-        val cached = redisTemplate.opsForValue().get(key) as? List<GeoLocationDto>
-        if (cached != null) {
-            println("Cache hit for key: $key: $cached")
-            redisTemplate.opsForValue().set(key, cached, Duration.ofHours(24))
-            return cached
-        }
-
-        // Redis에 없으면 외부 API 호출
+        // 캐시에 없으면 외부 API 호출
         val result = weatherApiClient.fetchCoordinatesByCity(location, null, 5)
             .blockOptional()
             .map { response -> response.map { GeoLocationDto(it) } }
             .orElse(emptyList())
 
-        // 결과 Redis에 저장 (TTL: 24시간)
+        // 결과를 캐시에 저장
         if (result.isNotEmpty()) {
-            redisTemplate.opsForValue().set(key, result, java.time.Duration.ofHours(24))
+            geoCache.putGeoLocations(location, result)
         }
 
         return result
@@ -77,22 +66,15 @@ class GeoService(
      * @return 정규화된 도시 이름
      */
     fun normalizeCityName(rawCityName: String, lat: Double, lon: Double): String {
-        val key = normalizedKeyPrefix + rawCityName
+        // 캐시에서 조회
+        geoCache.getNormalizedCity(rawCityName)?.let { return it }
 
-        // Redis 캐시 조회
-        val cached = redisTemplate.opsForValue().get(key) as? String
-        if (cached != null) {
-            println("Cache hit for key: $key: $cached")
-            redisTemplate.opsForValue().set(key, cached, Duration.ofDays(7))
-            return cached
-        }
-
-        // 외부 API 호출 → 좌표 기반 도시명 조회
+        // 캐시에 없으면 좌표로 지역 이름 조회
         val normalized = getLocationFromCoordinates(lat, lon)
 
-        // Redis에 캐싱 (TTL: 7일)
+        // 결과를 캐시에 저장
         if (normalized != "알 수 없음") {
-            redisTemplate.opsForValue().set(key, normalized, Duration.ofDays(7))
+            geoCache.putNormalizedCity(rawCityName, normalized)
         }
 
         return normalized

--- a/src/main/java/com/team04/back/domain/weather/weather/controller/WeatherController.kt
+++ b/src/main/java/com/team04/back/domain/weather/weather/controller/WeatherController.kt
@@ -54,7 +54,7 @@ class WeatherController(
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) start: LocalDate,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) end: LocalDate
     ): List<WeatherInfoDto> {
-        val weatherInfos: List<WeatherInfo> = weatherService.getWeatherInfos(location, lat, lon, start, end)
+        val weatherInfos: List<WeatherInfo> = weatherService.getWeatherInfos(lat, lon, start, end, location)
         return weatherInfos.map { WeatherInfoDto(it) }
     }
 }

--- a/src/main/java/com/team04/back/domain/weather/weather/entity/WeatherInfo.kt
+++ b/src/main/java/com/team04/back/domain/weather/weather/entity/WeatherInfo.kt
@@ -91,7 +91,7 @@ class WeatherInfo(
     }
 
     // DailyData를 WeatherInfo로 매핑
-    fun updateFromDailyData(data: DailyData, location: String, date: LocalDate) {
+    fun applyDailyWeather(data: DailyData, location: String, date: LocalDate) {
         this.weather = Weather.fromCode(data.weather.first().id)
         this.description = this.weather.description
         this.dailyTemperatureGap = (data.temp?.max ?: 0.0) - (data.temp?.min ?: 0.0)
@@ -110,7 +110,7 @@ class WeatherInfo(
     }
 
     // TimeMachineData를 WeatherInfo로 매핑
-    fun updateFromTimeMachineData(data: TimeMachineData, location: String, date: LocalDate, minTemp: Double, maxTemp: Double) {
+    fun applyHistoricalWeather(data: TimeMachineData, location: String, date: LocalDate, minTemp: Double, maxTemp: Double) {
         val weather = Weather.fromCode(data.weather.first().id)
         val pop = if ((weather.code in 200 until 400) || (weather.code in 500 until 700)) 1.0 else 0.0
 

--- a/src/main/java/com/team04/back/domain/weather/weather/entity/WeatherInfo.kt
+++ b/src/main/java/com/team04/back/domain/weather/weather/entity/WeatherInfo.kt
@@ -2,8 +2,11 @@ package com.team04.back.domain.weather.weather.entity
 
 import com.team04.back.domain.weather.weather.enums.Weather
 import com.team04.back.global.jpa.entity.BaseEntity
+import com.team04.back.infra.weather.dto.DailyData
+import com.team04.back.infra.weather.dto.TimeMachineData
 import jakarta.persistence.*
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "weather_info")
@@ -81,4 +84,48 @@ class WeatherInfo(
         location = "",
         date = LocalDate.now()
     )
+
+    // 3시간 이내에 수정된 데이터인지 확인
+    fun isValid(): Boolean {
+        return modifyDate.isAfter(LocalDateTime.now().minusHours(3))
+    }
+
+    // DailyData를 WeatherInfo로 매핑
+    fun updateFromDailyData(data: DailyData, location: String, date: LocalDate) {
+        this.weather = Weather.fromCode(data.weather.first().id)
+        this.description = this.weather.description
+        this.dailyTemperatureGap = (data.temp?.max ?: 0.0) - (data.temp?.min ?: 0.0)
+        this.feelsLikeTemperature = data.feelsLike?.day ?: 0.0
+        this.maxTemperature = data.temp?.max ?: 0.0
+        this.minTemperature = data.temp?.min ?: 0.0
+        this.location = location
+        this.date = date
+        this.pop = data.pop
+        this.rain = data.rain
+        this.snow = data.snow
+        this.humidity = data.humidity
+        this.windSpeed = data.windSpeed
+        this.windDeg = data.windDeg
+        this.uvi = data.uvi
+    }
+
+    // TimeMachineData를 WeatherInfo로 매핑
+    fun updateFromTimeMachineData(data: TimeMachineData, location: String, date: LocalDate, minTemp: Double, maxTemp: Double) {
+        val weather = Weather.fromCode(data.weather.first().id)
+        val pop = if ((weather.code in 200 until 400) || (weather.code in 500 until 700)) 1.0 else 0.0
+
+        this.weather = weather
+        this.description = data.weather.first().description
+        this.dailyTemperatureGap = maxTemp - minTemp
+        this.feelsLikeTemperature = data.feelsLike
+        this.maxTemperature = maxTemp
+        this.minTemperature = minTemp
+        this.location = location
+        this.date = date
+        this.pop = pop
+        this.humidity = data.humidity
+        this.windSpeed = data.windSpeed
+        this.windDeg = data.windDeg
+        this.uvi = data.uvi
+    }
 }

--- a/src/main/java/com/team04/back/domain/weather/weather/service/WeatherService.kt
+++ b/src/main/java/com/team04/back/domain/weather/weather/service/WeatherService.kt
@@ -2,7 +2,6 @@ package com.team04.back.domain.weather.weather.service
 
 import com.team04.back.domain.weather.geo.service.GeoService
 import com.team04.back.domain.weather.weather.entity.WeatherInfo
-import com.team04.back.domain.weather.weather.enums.Weather
 import com.team04.back.domain.weather.weather.repository.WeatherRepository
 import com.team04.back.infra.weather.WeatherApiClient
 import com.team04.back.infra.weather.dto.DailyData
@@ -73,7 +72,7 @@ class WeatherService(
         val weatherInfo = weatherRepository.findByLocationAndDate(location, date)
 
         // 조회 결과가 있고 유효한 경우
-        if (weatherInfo != null && isValid(weatherInfo)) {
+        if (weatherInfo != null && weatherInfo.isValid()) {
             return weatherInfo
         }
         // 조회 결과가 없거나 유효하지 않은 경우
@@ -121,13 +120,7 @@ class WeatherService(
         return result
     }
 
-    // 유효성 검사: 마지막 업데이트가 3시간 이내인지 확인
-    private fun isValid(weatherInfo: WeatherInfo): Boolean {
-        val lastUpdated = weatherInfo.modifyDate
-        return lastUpdated.isAfter(LocalDateTime.now().minusHours(3))
-    }
-
-    // 요청된 날짜에 따라 날씨 정보를 업데이트
+    // 요청된 날짜에 따라 날씨 정보 업데이트 함수 호출
     private fun updateWeatherInfo(info: WeatherInfo, location: String, lat: Double, lon: Double, date: LocalDate): WeatherInfo {
         val today = LocalDate.now()
 
@@ -159,27 +152,8 @@ class WeatherService(
         requireNotNull(matchedDaily) { "해당 날짜($date)에 대한 예보 데이터가 존재하지 않습니다." }
 
         // 날씨 정보 갱신 및 저장
-        mapDailyDataToWeatherInfo(info, matchedDaily, location, date)
+        info.updateFromDailyData(matchedDaily, location, date)
         return weatherRepository.save(info)
-    }
-
-    // DailyData를 WeatherInfo로 매핑
-    private fun mapDailyDataToWeatherInfo(info: WeatherInfo, data: DailyData, location: String, date: LocalDate) {
-        info.weather = Weather.fromCode(data.weather.first().id)
-        info.description = info.weather.description
-        info.dailyTemperatureGap = (data.temp?.max ?: 0.0) - (data.temp?.min ?: 0.0)
-        info.feelsLikeTemperature = data.feelsLike?.day ?: 0.0
-        info.maxTemperature = data.temp?.max ?: 0.0
-        info.minTemperature = data.temp?.min ?: 0.0
-        info.location = location
-        info.date = date
-        info.pop = data.pop
-        info.rain = data.rain
-        info.snow = data.snow
-        info.humidity = data.humidity
-        info.windSpeed = data.windSpeed
-        info.windDeg = data.windDeg
-        info.uvi = data.uvi
     }
 
     // Time Machine API를 통해 날씨 정보를 업데이트
@@ -200,32 +174,7 @@ class WeatherService(
         val maxTemp = hourlyData.maxOfOrNull { it.temp } ?: 0.0
         val data = hourlyData.first()
 
-        mapTimeMachineDataToWeatherInfo(info, data, location, date, minTemp, maxTemp)
+        info.updateFromTimeMachineData(data, location, date, minTemp, maxTemp)
         return weatherRepository.save(info)
-    }
-
-    // TimeMachineData를 WeatherInfo로 매핑
-    private fun mapTimeMachineDataToWeatherInfo(info: WeatherInfo, data: TimeMachineData, location: String, date: LocalDate, minTemp: Double, maxTemp: Double) {
-        val weather = Weather.fromCode(data.weather.first().id)
-        var pop = 0.0
-        val weatherCode = weather.code
-
-        if ((weatherCode in 200 until 400) || (weatherCode in 500 until 700)) {
-            pop = 1.0
-        }
-
-        info.weather = weather
-        info.description = data.weather.first().description
-        info.dailyTemperatureGap = maxTemp - minTemp
-        info.feelsLikeTemperature = data.feelsLike
-        info.maxTemperature = maxTemp
-        info.minTemperature = minTemp
-        info.location = location
-        info.date = date
-        info.pop = pop
-        info.humidity = data.humidity
-        info.windSpeed = data.windSpeed
-        info.windDeg = data.windDeg
-        info.uvi = data.uvi
     }
 }

--- a/src/main/java/com/team04/back/domain/weather/weather/service/WeatherService.kt
+++ b/src/main/java/com/team04/back/domain/weather/weather/service/WeatherService.kt
@@ -42,83 +42,74 @@ class WeatherService(
         } else {
             // 지역 이름 정규화
             val normalized = geoService.normalizeCityName(location, lat, lon)
-            return getWeatherInfos(normalized, lat, lon, date, date.plusDays(6))
+            return getWeatherInfos(lat, lon, date, date.plusDays(6), normalized)
         }
     }
 
     /**
-     * 좌표와 날짜를 이용하여 날씨 정보 단건을 조회합니다.
+     * 좌표, 날짜, (선택적) 지역 이름을 이용하여 날씨 정보 단건을 조회합니다.
      * @param lat 위도
      * @param lon 경도
      * @param date 조회할 날짜
+     * @param location (선택적) 지역 이름
      * @return 해당 좌표와 날짜에 대한 날씨 정보
      */
     @Transactional
-    fun getWeatherInfo(lat: Double, lon: Double, date: LocalDate): WeatherInfo {
-        val location = geoService.getLocationFromCoordinates(lat, lon)
-        return getWeatherInfo(location, lat, lon, date)
-    }
+    fun getWeatherInfo(
+        lat: Double,
+        lon: Double,
+        date: LocalDate,
+        location: String? = null
+    ): WeatherInfo {
+        // 지역 이름이 제공되지 않은 경우, 좌표로부터 지역 이름 조회
+        val resolvedLocation = location ?: geoService.getLocationFromCoordinates(lat, lon)
 
-    /**
-     * 지역 이름과 날짜를 이용하여 날씨 정보 단건을 조회합니다.
-     * @param location 지역 이름
-     * @param lat 위도
-     * @param lon 경도
-     * @param date 조회할 날짜
-     * @return 해당 지역과 날짜에 대한 날씨 정보
-     */
-    @Transactional
-    fun getWeatherInfo(location: String, lat: Double, lon: Double, date: LocalDate): WeatherInfo {
-        val weatherInfo = weatherRepository.findByLocationAndDate(location, date)
+        // 기존에 저장된 날씨 정보 조회
+        val weatherInfo = weatherRepository.findByLocationAndDate(resolvedLocation, date)
 
         // 조회 결과가 있고 유효한 경우
         if (weatherInfo != null && weatherInfo.isValid()) {
             return weatherInfo
         }
+
         // 조회 결과가 없거나 유효하지 않은 경우
         val info = weatherInfo ?: WeatherInfo()
-        return updateWeatherInfo(info, location, lat, lon, date)
+        return updateWeatherInfo(info, resolvedLocation, lat, lon, date)
     }
 
     /**
-     * 좌표와 날짜 범위를 이용하여 날씨 정보 리스트를 조회합니다.
+     * 좌표, 날짜 범위, (선택적) 지역 이름을 이용하여 날씨 정보 리스트를 조회합니다.
      * @param lat 위도
      * @param lon 경도
      * @param startDate 시작 날짜
      * @param endDate 종료 날짜
+     * @param location (선택적) 지역 이름
      * @return 해당 좌표와 날짜 범위에 대한 날씨 정보 리스트
      */
     @Transactional
-    fun getWeatherInfos(lat: Double, lon: Double, startDate: LocalDate, endDate: LocalDate): List<WeatherInfo> {
-        val location = geoService.getLocationFromCoordinates(lat, lon)
-        return getWeatherInfos(location, lat, lon, startDate, endDate)
-    }
-
-    /**
-     * 지역 이름과 날짜 범위를 이용하여 날씨 정보 리스트를 조회합니다.
-     * @param lat 위도
-     * @param lon 경도
-     * @param startDate 시작 날짜
-     * @param endDate 종료 날짜
-     * @return 해당 좌표와 날짜 범위에 대한 날씨 정보 리스트
-     */
-    @Transactional
-    fun getWeatherInfos(location: String, lat: Double, lon: Double, startDate: LocalDate, endDate: LocalDate): List<WeatherInfo> {
+    fun getWeatherInfos(
+        lat: Double,
+        lon: Double,
+        startDate: LocalDate,
+        endDate: LocalDate,
+        location: String? = null
+    ): List<WeatherInfo> {
         // 시작 날짜와 종료 날짜 유효성 검사
         require(!startDate.isAfter(endDate)) {
             "시작 날짜($startDate)는 종료 날짜($endDate)보다 이후일 수 없습니다."
         }
 
+        // 지역 이름이 제공되지 않은 경우, 좌표로부터 지역 이름 조회
+        val resolvedLocation = location ?: geoService.getLocationFromCoordinates(lat, lon)
+
         // 범위 내의 모든 날짜에 대해 날씨 정보 조회
-        val result = mutableListOf<WeatherInfo>()
-        var date = startDate
-        while (!date.isAfter(endDate)) {
-            val info = getWeatherInfo(location, lat, lon, date)
-            result.add(info)
-            date = date.plusDays(1)
+        return (0..endDate.toEpochDay() - startDate.toEpochDay()).map {
+            val date = startDate.plusDays(it)
+            getWeatherInfo(lat, lon, date, resolvedLocation)
         }
-        return result
     }
+
+    // ==================== Private Methods ====================
 
     // 요청된 날짜에 따라 날씨 정보 업데이트 함수 호출
     private fun updateWeatherInfo(info: WeatherInfo, location: String, lat: Double, lon: Double, date: LocalDate): WeatherInfo {
@@ -152,7 +143,7 @@ class WeatherService(
         requireNotNull(matchedDaily) { "해당 날짜($date)에 대한 예보 데이터가 존재하지 않습니다." }
 
         // 날씨 정보 갱신 및 저장
-        info.updateFromDailyData(matchedDaily, location, date)
+        info.applyDailyWeather(matchedDaily, location, date)
         return weatherRepository.save(info)
     }
 
@@ -174,7 +165,7 @@ class WeatherService(
         val maxTemp = hourlyData.maxOfOrNull { it.temp } ?: 0.0
         val data = hourlyData.first()
 
-        info.updateFromTimeMachineData(data, location, date, minTemp, maxTemp)
+        info.applyHistoricalWeather(data, location, date, minTemp, maxTemp)
         return weatherRepository.save(info)
     }
 }

--- a/src/main/java/com/team04/back/infra/cache/GeoCache.kt
+++ b/src/main/java/com/team04/back/infra/cache/GeoCache.kt
@@ -1,0 +1,47 @@
+package com.team04.back.infra.cache
+
+import com.team04.back.domain.weather.geo.dto.GeoLocationDto
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class GeoCache(
+    private val redisTemplate: RedisTemplate<String, Any>
+) {
+    private val cacheKeyPrefix = "geo:search:"
+    private val normalizedKeyPrefix = "geo:normalized:"
+
+    private val geoLocationTtl: Duration = Duration.ofDays(7)
+    private val normalizedCityTtl: Duration = Duration.ofDays(7)
+
+    fun getGeoLocations(location: String): List<GeoLocationDto>? {
+        val key = cacheKeyPrefix + location
+        @Suppress("UNCHECKED_CAST")
+        val cached = redisTemplate.opsForValue().get(key) as? List<GeoLocationDto>
+        if (cached != null) {
+            redisTemplate.expire(key, geoLocationTtl)
+        }
+        return cached
+    }
+
+
+    fun putGeoLocations(location: String, data: List<GeoLocationDto>) {
+        val key = cacheKeyPrefix + location
+        redisTemplate.opsForValue().set(key, data, geoLocationTtl)
+    }
+
+    fun getNormalizedCity(rawCityName: String): String? {
+        val key = normalizedKeyPrefix + rawCityName
+        val cached = redisTemplate.opsForValue().get(key) as? String
+        if (cached != null) {
+            redisTemplate.expire(key, normalizedCityTtl)
+        }
+        return cached
+    }
+
+    fun putNormalizedCity(rawCityName: String, normalized: String) {
+        val key = normalizedKeyPrefix + rawCityName
+        redisTemplate.opsForValue().set(key, normalized, normalizedCityTtl)
+    }
+}

--- a/src/test/java/com/team04/back/domain/cloth/cloth/controller/ClothControllerTest.java
+++ b/src/test/java/com/team04/back/domain/cloth/cloth/controller/ClothControllerTest.java
@@ -61,7 +61,7 @@ class ClothControllerTest {
 
         List<CategoryClothDto> mockCloths = List.of(CLOTH_1, CLOTH_2);
 
-        when(weatherService.getWeatherInfo(anyDouble(), anyDouble(), any()))
+        when(weatherService.getWeatherInfo(anyDouble(), anyDouble(), any(), any()))
                 .thenReturn(mockWeatherInfo);
 
         //현재 체감온도 기준으로
@@ -89,7 +89,7 @@ class ClothControllerTest {
         List<CategoryClothDto> mockCloths = List.of(CLOTH_1, CLOTH_2);
 
 
-        when(weatherService.getWeatherInfo(anyDouble(), anyDouble(), any()))
+        when(weatherService.getWeatherInfo(anyDouble(), anyDouble(), any(), any()))
                 .thenReturn(mockWeatherInfo);
 
         when(clothService.findClothByWeather(mockWeatherInfo.getFeelsLikeTemperature()))

--- a/src/test/java/com/team04/back/domain/review/review/controller/ReviewControllerTest.kt
+++ b/src/test/java/com/team04/back/domain/review/review/controller/ReviewControllerTest.kt
@@ -441,7 +441,7 @@ class ReviewControllerTest {
         val saved = weatherRepository.save(mockWeatherInfo)
 
         every { geoService.getCoordinatesFromLocation("Seoul", "KR") } returns listOf(37.5665, 126.9780)
-        every { weatherService.getWeatherInfo("Seoul", any(), any(), any()) } returns saved
+        every { weatherService.getWeatherInfo(any(), any(), any(), "Seoul") } returns saved
     }
 
 

--- a/src/test/java/com/team04/back/domain/weather/weather/service/WeatherServiceTest.kt
+++ b/src/test/java/com/team04/back/domain/weather/weather/service/WeatherServiceTest.kt
@@ -89,7 +89,7 @@ class WeatherServiceTest {
         val expected = weatherInfoList.take(7)
 
         whenever(geoService.normalizeCityName(location, lat, lon)).thenReturn(normalized)
-        doReturn(expected).`when`(spyWeatherService).getWeatherInfos(normalized, lat, lon, startDate, endDate)
+        doReturn(expected).`when`(spyWeatherService).getWeatherInfos(lat, lon, startDate, endDate, normalized)
 
         val result = spyWeatherService.getWeeklyWeather(location, lat, lon)
 
@@ -184,8 +184,6 @@ class WeatherServiceTest {
     fun getWeatherInfos_InvalidDateRange_ThrowsException() {
         val startDate = today.plusDays(1)
         val endDate = today
-
-        whenever(geoService.getLocationFromCoordinates(lat, lon)).thenReturn(location)
 
         assertThrows<IllegalArgumentException> {
             weatherService.getWeatherInfos(lat, lon, startDate, endDate)


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- weather 및 geo 도메인 구조 개선 및 관련 코드에 반영

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

- WeatherService 내의 엔티티 로직 분리
  - isValid, mapDailyDataToWeatherInfo, mapTimeMachineDataToWeatherInfo 를
WeatherInfo 엔티티 메서드(isValid, applyDailyWeather, applyHistoricalWeather)로 이동

- WeatherService 내의 오버로딩 정리 → 단일 메서드로 통합
  - getWeatherInfo / getWeatherInfos 오버로드 버전을 통합하고 location: String? = null 파라미터로 처리

- GeoService 내의 캐싱 로직 분리
  - GeoCache 컴포넌트를 infra.cache 패키지로 분리하여 Redis 접근 책임 위임

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #54

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

- WeatherService 내의 함수를 참조하는 다른 도메인의 코드도 일부 수정되었으니 rebase 후 작업하시는 걸 권장드립니다.
- 정상적인 빌드를 위해 User 파일을 임의로 수정하였습니다. 담당자 분 확인바랍니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
