### PR TITLE
feature: Review 도메인에 회원 기능 추가

### DIFF
--- a/src/main/java/com/team04/back/domain/cloth/cloth/entity/ClothInfo.kt
+++ b/src/main/java/com/team04/back/domain/cloth/cloth/entity/ClothInfo.kt
@@ -13,9 +13,12 @@ import jakarta.persistence.Enumerated
 @Entity
 class ClothInfo(
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     var clothName: ClothName,
+
     @Column(nullable = false)
     var imageUrl: String,
+
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     var category: Category,

--- a/src/main/java/com/team04/back/domain/cloth/cloth/enums/ClothName.kt
+++ b/src/main/java/com/team04/back/domain/cloth/cloth/enums/ClothName.kt
@@ -61,5 +61,6 @@ enum class ClothName(val category: Category) {
     BACKPACK(EXTRA),       // 백팩
     CROSSBODY_BAG(EXTRA),  // 크로스백
     SUNGLASSES(EXTRA),     // 선글라스
-    UMBRELLA(EXTRA)        // 우산
+    UMBRELLA(EXTRA),        // 우산
+    MASK(EXTRA)             // 마스크
 }

--- a/src/main/java/com/team04/back/domain/cloth/cloth/repository/ClothRepository.kt
+++ b/src/main/java/com/team04/back/domain/cloth/cloth/repository/ClothRepository.kt
@@ -18,5 +18,5 @@ interface ClothRepository : JpaRepository<ClothInfo, Int> {
     @Query("SELECT c FROM ClothInfo c WHERE :temperature BETWEEN c.minFeelsLike AND c.maxFeelsLike")
     fun findByTemperature(@Param("temperature") temperature: Double?): List<ClothInfo>
 
-    fun findByClothNameAndStyle(clothName: ClothName, style: Style?) : ClothInfo?
+    fun findFirstByClothNameAndStyle(clothName: ClothName, style: Style?) : ClothInfo?
 }

--- a/src/main/java/com/team04/back/domain/cloth/cloth/service/ClothService.kt
+++ b/src/main/java/com/team04/back/domain/cloth/cloth/service/ClothService.kt
@@ -72,6 +72,6 @@ class ClothService(
     }
 
     fun findByClothNameAndStyle(clothName: ClothName, style: Style?) : ClothInfo? {
-        return clothRepository.findByClothNameAndStyle(clothName, style)
+        return clothRepository.findFirstByClothNameAndStyle(clothName, style)
     }
 }

--- a/src/main/java/com/team04/back/domain/review/review/controller/ReviewController.kt
+++ b/src/main/java/com/team04/back/domain/review/review/controller/ReviewController.kt
@@ -146,16 +146,19 @@ class ReviewController(
     fun createReview(
         @RequestBody @Valid createReviewReqBody: CreateReviewReqBody
     ): RsData<ReviewDto> {
+//        val user: User? = rq.member
+
         val review = reviewService.createReview(
-            createReviewReqBody.email,
-            createReviewReqBody.password,
-            createReviewReqBody.imageUrl,
-            createReviewReqBody.title,
-            createReviewReqBody.sentence,
-            createReviewReqBody.tagString,
-            createReviewReqBody.cityName,
-            createReviewReqBody.countryCode,
-            createReviewReqBody.date,
+//            user,
+            email = createReviewReqBody.email,
+            password = createReviewReqBody.password,
+            imageUrl = createReviewReqBody.imageUrl,
+            title = createReviewReqBody.title,
+            sentence = createReviewReqBody.sentence,
+            tagString = createReviewReqBody.tagString,
+            cityName = createReviewReqBody.cityName,
+            countryCode = createReviewReqBody.countryCode,
+            date = createReviewReqBody.date,
             clothList = createReviewReqBody.clothList
         )
 

--- a/src/main/java/com/team04/back/domain/review/review/controller/ReviewController.kt
+++ b/src/main/java/com/team04/back/domain/review/review/controller/ReviewController.kt
@@ -115,14 +115,13 @@ class ReviewController(
     @Transactional
     @Operation(summary = "리뷰 삭제", description = "리뷰를 삭제합니다.")
     fun deleteReview(
-        @PathVariable id: Int,
-        @RequestBody passwordReqBody: VerifyPasswordReqBody
+        @PathVariable id: Int
     ): RsData<ReviewDto> {
 //        val user: User? = rq.member
 
         val review = reviewService.findById(id).getOrThrow()
 
-//        reviewService.checkCanDelete(review, user, passwordReqBody.password)
+//        user?.let { reviewService.checkCanDelete(review, user) }
 
         reviewService.deleteReview(review)
 
@@ -178,14 +177,13 @@ class ReviewController(
     @Operation(summary = "리뷰 수정", description = "리뷰를 수정합니다.")
     fun modifyReview(
         @PathVariable id: Int,
-        @RequestBody @Valid modifyReviewReqBody: ModifyReviewReqBody,
-        @RequestBody passwordReqBody: VerifyPasswordReqBody
+        @RequestBody @Valid modifyReviewReqBody: ModifyReviewReqBody
     ): RsData<ReviewDto> {
 //        val user: User? = rq.member
 
         var review = reviewService.findById(id).getOrThrow()
 
-//        reviewService.checkCanModify(review, user, passwordReqBody.password)
+//        user?.let { reviewService.checkCanModify(review, user) }
 
         review = reviewService.modifyReview(
             review,

--- a/src/main/java/com/team04/back/domain/review/review/controller/ReviewController.kt
+++ b/src/main/java/com/team04/back/domain/review/review/controller/ReviewController.kt
@@ -1,10 +1,7 @@
 package com.team04.back.domain.review.review.controller
 
 import com.team04.back.domain.cloth.cloth.entity.ClothInfo
-import com.team04.back.domain.review.review.dto.CreateReviewReqBody
-import com.team04.back.domain.review.review.dto.ModifyReviewReqBody
-import com.team04.back.domain.review.review.dto.ReviewDetailDto
-import com.team04.back.domain.review.review.dto.ReviewDto
+import com.team04.back.domain.review.review.dto.*
 import com.team04.back.domain.review.review.entity.Review
 import com.team04.back.domain.review.review.service.ReviewService
 import com.team04.back.global.rsData.RsData
@@ -15,7 +12,6 @@ import com.team04.back.standard.extensions.getOrThrow
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import jakarta.validation.constraints.NotBlank
 import org.springframework.data.domain.Page
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.transaction.annotation.Transactional
@@ -83,11 +79,6 @@ class ReviewController(
         return ReviewDetailDto.from(review, recommendedClothInfo, nonRecommendedClothInfo)
     }
 
-
-    data class VerifyPasswordReqBody(
-        @field:NotBlank val password: String
-    )
-
     /**
      * 리뷰의 비밀번호를 검증합니다.
      * @param id 리뷰 ID
@@ -103,7 +94,7 @@ class ReviewController(
     ): RsData<Boolean> {
         val review = reviewService.findById(id).getOrThrow()
 
-        val isVerified = reviewService.verifyPassword(review, passwordReqBody.password)
+        val isVerified = reviewService.verifyPassword(review, passwordReqBody.password!!)
         if (!isVerified) {
             return RsData("400-1", "비밀번호가 일치하지 않습니다.", false)
         }
@@ -123,8 +114,15 @@ class ReviewController(
     @DeleteMapping("/{id}")
     @Transactional
     @Operation(summary = "리뷰 삭제", description = "리뷰를 삭제합니다.")
-    fun deleteReview(@PathVariable id: Int): RsData<ReviewDto> {
+    fun deleteReview(
+        @PathVariable id: Int,
+        @RequestBody passwordReqBody: VerifyPasswordReqBody
+    ): RsData<ReviewDto> {
+//        val user: User? = rq.member
+
         val review = reviewService.findById(id).getOrThrow()
+
+//        reviewService.checkCanDelete(review, user, passwordReqBody.password)
 
         reviewService.deleteReview(review)
 
@@ -180,9 +178,14 @@ class ReviewController(
     @Operation(summary = "리뷰 수정", description = "리뷰를 수정합니다.")
     fun modifyReview(
         @PathVariable id: Int,
-        @RequestBody @Valid modifyReviewReqBody: ModifyReviewReqBody
+        @RequestBody @Valid modifyReviewReqBody: ModifyReviewReqBody,
+        @RequestBody passwordReqBody: VerifyPasswordReqBody
     ): RsData<ReviewDto> {
+//        val user: User? = rq.member
+
         var review = reviewService.findById(id).getOrThrow()
+
+//        reviewService.checkCanModify(review, user, passwordReqBody.password)
 
         review = reviewService.modifyReview(
             review,

--- a/src/main/java/com/team04/back/domain/review/review/controller/ReviewController.kt
+++ b/src/main/java/com/team04/back/domain/review/review/controller/ReviewController.kt
@@ -90,7 +90,7 @@ class ReviewController(
     @Operation(summary = "리뷰 비밀번호 검증", description = "리뷰의 비밀번호를 검증합니다.")
     fun verifyPassword(
         @PathVariable id: Int,
-        @RequestBody passwordReqBody: VerifyPasswordReqBody
+        @RequestBody @Valid passwordReqBody: VerifyPasswordReqBody
     ): RsData<Boolean> {
         val review = reviewService.findById(id).getOrThrow()
 

--- a/src/main/java/com/team04/back/domain/review/review/controller/ReviewController.kt
+++ b/src/main/java/com/team04/back/domain/review/review/controller/ReviewController.kt
@@ -7,8 +7,6 @@ import com.team04.back.domain.review.review.dto.ReviewDetailDto
 import com.team04.back.domain.review.review.dto.ReviewDto
 import com.team04.back.domain.review.review.entity.Review
 import com.team04.back.domain.review.review.service.ReviewService
-import com.team04.back.domain.weather.geo.service.GeoService
-import com.team04.back.domain.weather.weather.service.WeatherService
 import com.team04.back.global.rsData.RsData
 import com.team04.back.standard.dto.PageDto
 import com.team04.back.standard.dto.ReviewSearchDto
@@ -29,8 +27,6 @@ import java.time.LocalDate
 @Tag(name = "ReviewController", description = "리뷰 API")
 class ReviewController(
     private val reviewService: ReviewService,
-    private val weatherService: WeatherService,
-    private val geoService: GeoService,
 ) {
     /**
      * 이 API는 location, date, feelsLikeTemperature, month 파라미터를 사용하여 필터링된 리뷰 목록을 조회합니다.
@@ -160,7 +156,7 @@ class ReviewController(
             createReviewReqBody.cityName,
             createReviewReqBody.countryCode,
             createReviewReqBody.date,
-            createReviewReqBody.clothList
+            clothList = createReviewReqBody.clothList
         )
 
         return RsData(
@@ -194,7 +190,7 @@ class ReviewController(
             modifyReviewReqBody.cityName,
             modifyReviewReqBody.countryCode,
             modifyReviewReqBody.date,
-            modifyReviewReqBody.clothList
+            clothList = modifyReviewReqBody.clothList
         )
 
         return RsData(

--- a/src/main/java/com/team04/back/domain/review/review/dto/CreateReviewReqBody.kt
+++ b/src/main/java/com/team04/back/domain/review/review/dto/CreateReviewReqBody.kt
@@ -1,15 +1,14 @@
 package com.team04.back.domain.review.review.dto
 
 import jakarta.validation.Valid
-import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDate
 
 data class CreateReviewReqBody(
-        @field:NotBlank @field:Email val email: String,
-        @field:NotBlank @field:Size(min = 4) val password: String,
+        val email: String?,
+        val password: String?,
         @field:NotBlank @field:Size(min = 2, max = 100) val title: String,
         @field:NotBlank @field:Size(min = 2, max = 500) val sentence: String,
         val tagString: String?,

--- a/src/main/java/com/team04/back/domain/review/review/dto/ReviewDetailDto.kt
+++ b/src/main/java/com/team04/back/domain/review/review/dto/ReviewDetailDto.kt
@@ -7,7 +7,8 @@ import com.team04.back.domain.weather.weather.dto.WeatherInfoDto
 
 data class ReviewDetailDto(
     val id: Int,
-    val email: String,
+    val userId: Int?,
+    val email: String?,
     val imageUrl: String?,
     val title: String,
     val sentence: String,
@@ -24,6 +25,7 @@ data class ReviewDetailDto(
         ): ReviewDetailDto {
             return ReviewDetailDto(
                 review.id,
+                review.user?.id,
                 review.email,
                 review.imageUrl,
                 review.title,

--- a/src/main/java/com/team04/back/domain/review/review/dto/ReviewDto.kt
+++ b/src/main/java/com/team04/back/domain/review/review/dto/ReviewDto.kt
@@ -5,7 +5,8 @@ import com.team04.back.domain.weather.weather.dto.WeatherInfoDto
 
 data class ReviewDto(
     val id: Int,
-    val email: String,
+    val userId: Int?,
+    val email: String?,
     val imageUrl: String?,
     val title: String,
     val weatherInfoDto: WeatherInfoDto
@@ -14,6 +15,7 @@ data class ReviewDto(
         fun from(review: Review): ReviewDto {
             return ReviewDto(
                 review.id,
+                review.user?.id,
                 review.email,
                 review.imageUrl,
                 review.title,

--- a/src/main/java/com/team04/back/domain/review/review/dto/VerifyPasswordReqBody.kt
+++ b/src/main/java/com/team04/back/domain/review/review/dto/VerifyPasswordReqBody.kt
@@ -1,0 +1,5 @@
+package com.team04.back.domain.review.review.dto
+
+data class VerifyPasswordReqBody(
+        val password: String?
+)

--- a/src/main/java/com/team04/back/domain/review/review/dto/VerifyPasswordReqBody.kt
+++ b/src/main/java/com/team04/back/domain/review/review/dto/VerifyPasswordReqBody.kt
@@ -1,5 +1,7 @@
 package com.team04.back.domain.review.review.dto
 
+import jakarta.validation.constraints.NotBlank
+
 data class VerifyPasswordReqBody(
-        val password: String?
+        @field:NotBlank val password: String?
 )

--- a/src/main/java/com/team04/back/domain/review/review/entity/Review.kt
+++ b/src/main/java/com/team04/back/domain/review/review/entity/Review.kt
@@ -20,10 +20,8 @@ class Review(
     @JoinColumn(name = "user_id")
     val user: User? = user  // 회원일 경우
 
-    @Column(nullable = false)
     val email: String? = email  // 비회원일 경우
 
-    @Column(nullable = false)
     val password: String? = password  // 비회원일 경우
 
     @Column(length = 100, nullable = false)

--- a/src/main/java/com/team04/back/domain/review/review/entity/Review.kt
+++ b/src/main/java/com/team04/back/domain/review/review/entity/Review.kt
@@ -1,24 +1,30 @@
 package com.team04.back.domain.review.review.entity
 
+import com.team04.back.domain.user.user.entity.User
 import com.team04.back.domain.weather.weather.entity.WeatherInfo
 import com.team04.back.global.jpa.entity.BaseEntity
 import jakarta.persistence.*
 
 @Entity
 class Review(
-    email: String,
-    password: String,
+    user: User? = null,
+    email: String?,
+    password: String?,
     title: String,
     sentence: String,
     tagString: String?,
     imageUrl: String?,
     weatherInfo: WeatherInfo
 ) : BaseEntity() {
-    @Column(nullable = false)
-    val email: String = email
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User? = user  // 회원일 경우
 
     @Column(nullable = false)
-    val password: String = password
+    val email: String? = email  // 비회원일 경우
+
+    @Column(nullable = false)
+    val password: String? = password  // 비회원일 경우
 
     @Column(length = 100, nullable = false)
     var title: String = title

--- a/src/main/java/com/team04/back/domain/review/review/service/ReviewService.kt
+++ b/src/main/java/com/team04/back/domain/review/review/service/ReviewService.kt
@@ -7,6 +7,7 @@ import com.team04.back.domain.review.review.entity.Review
 import com.team04.back.domain.review.review.entity.ReviewClothInfo
 import com.team04.back.domain.review.review.repository.ReviewClothInfoRepository
 import com.team04.back.domain.review.review.repository.ReviewRepository
+import com.team04.back.domain.user.user.entity.User
 import com.team04.back.domain.weather.geo.service.GeoService
 import com.team04.back.domain.weather.weather.entity.WeatherInfo
 import com.team04.back.domain.weather.weather.service.WeatherService
@@ -51,8 +52,9 @@ class ReviewService(
 
     @Transactional
     fun createReview(
-        email: String,
-        password: String,
+        user: User? = null,
+        email: String? = null,
+        password: String? = null,
         imageUrl: String?,
         title: String,
         sentence: String,
@@ -63,6 +65,8 @@ class ReviewService(
         weatherInfo: WeatherInfo? = null,
         clothList: List<ClothItemReqBody>?
     ): Review {
+        require((user != null) xor (email != null && password != null)) { "Either user or (email and password) must be provided, but not both" }
+
         val weatherInfo = weatherInfo ?: getWeatherInfo(cityName, countryCode, date)
 
         val review = Review(null, email, password, title, sentence, tagString, imageUrl, weatherInfo)

--- a/src/main/java/com/team04/back/domain/review/review/service/ReviewService.kt
+++ b/src/main/java/com/team04/back/domain/review/review/service/ReviewService.kt
@@ -57,13 +57,15 @@ class ReviewService(
         title: String,
         sentence: String,
         tagString: String?,
-        cityName: String,
-        countryCode: String,
-        date: LocalDate,
+        cityName: String? = null,
+        countryCode: String? = null,
+        date: LocalDate? = null,
+        weatherInfo: WeatherInfo? = null,
         clothList: List<ClothItemReqBody>?
     ): Review {
-        val weatherInfo = getWeatherInfo(cityName, countryCode, date)
-        val review = Review(email, password, title, sentence, tagString, imageUrl, weatherInfo)
+        val weatherInfo = weatherInfo ?: getWeatherInfo(cityName, countryCode, date)
+
+        val review = Review(null, email, password, title, sentence, tagString, imageUrl, weatherInfo)
         val savedReview = reviewRepository.save(review)
         createClothInfo(savedReview.id, clothList)
 
@@ -77,16 +79,18 @@ class ReviewService(
         sentence: String,
         tagString: String?,
         imageUrl: String?,
-        cityName: String,
-        countryCode: String,
-        date: LocalDate,
+        cityName: String? = null,
+        countryCode: String? = null,
+        date: LocalDate? = null,
+        weatherInfo: WeatherInfo? = null,
         clothList: List<ClothItemReqBody>?
     ): Review {
         val newTitle = title.takeIf { it != review.title }
         val newSentence = sentence.takeIf { it != review.sentence }
         val newTagString = tagString.takeIf { it != review.tagString }
         val newImageUrl = imageUrl.takeIf { it != review.imageUrl }
-        val newWeatherInfo = getWeatherInfo(cityName, countryCode, date).takeIf { it != review.weatherInfo }
+        val weatherInfo = weatherInfo ?: getWeatherInfo(cityName, countryCode, date)
+        val newWeatherInfo = weatherInfo.takeIf { it != review.weatherInfo }
 
         clothList?.let {
             updateClothInfoEfficiently(review.id, clothList)
@@ -190,7 +194,11 @@ class ReviewService(
         }
     }
 
-    private fun getWeatherInfo(cityName: String, countryCode: String, date: LocalDate): WeatherInfo {
+    private fun getWeatherInfo(cityName: String?, countryCode: String?, date: LocalDate?): WeatherInfo {
+        requireNotNull(cityName) { "City name must not be null" }
+        requireNotNull(countryCode) { "Country code must not be null" }
+        requireNotNull(date) { "Date must not be null" }
+
         val coordinates = geoService.getCoordinatesFromLocation(cityName, countryCode)
         return weatherService.getWeatherInfo(
             coordinates[0],
@@ -198,46 +206,5 @@ class ReviewService(
             date,
             cityName
         )
-    }
-
-    @Transactional
-    fun createReview(
-        email: String,
-        password: String,
-        imageUrl: String?,
-        title: String,
-        sentence: String,
-        tagString: String?,
-        weatherInfo: WeatherInfo,
-        clothList: List<ClothItemReqBody>?
-    ): Review {
-        val review = Review(email, password, title, sentence, tagString, imageUrl, weatherInfo)
-        val savedReview = reviewRepository.save(review)
-        createClothInfo(savedReview.id, clothList)
-
-        return savedReview
-    }
-
-    @Transactional
-    fun modifyReview(
-        review: Review,
-        title: String,
-        sentence: String,
-        tagString: String?,
-        imageUrl: String?,
-        weatherInfo: WeatherInfo,
-        clothList: List<ClothItemReqBody>?
-    ): Review {
-        val newTitle = title.takeIf { it != review.title }
-        val newSentence = sentence.takeIf { it != review.sentence }
-        val newTagString = tagString.takeIf { it != review.tagString }
-        val newImageUrl = imageUrl.takeIf { it != review.imageUrl }
-        val newWeatherInfo = weatherInfo.takeIf { it != review.weatherInfo }
-
-        clothList?.let {
-            updateClothInfoEfficiently(review.id, clothList)
-        }
-
-        return review.modify(newTitle, newSentence, newTagString, newImageUrl, newWeatherInfo)
     }
 }

--- a/src/main/java/com/team04/back/domain/review/review/service/ReviewService.kt
+++ b/src/main/java/com/team04/back/domain/review/review/service/ReviewService.kt
@@ -49,6 +49,42 @@ class ReviewService(
 
     fun verifyPassword(review: Review, password: String): Boolean = review.password == password
 
+    fun checkCanDelete(review: Review, user: User?, password: String?) {
+        require((user != null) xor (password != null)) { "Either user or password must be provided, but not both" }
+
+        user?.let {
+            val reviewUser = review.user
+                ?: throw ServiceException("403-2", "회원 리뷰가 아니므로 회원 권한으로 삭제할 수 없습니다.")
+            if (it.id != reviewUser.id)
+                throw ServiceException("403-1", "${review.id}번 리뷰 삭제 권한이 없습니다.")
+        }
+
+        password?.let {
+            if (review.user != null)
+                throw ServiceException("403-3", "회원이 작성한 리뷰는 비밀번호로 삭제할 수 없습니다.")
+            if (review.password != it)
+                throw ServiceException("400-1", "비밀번호가 일치하지 않습니다.")
+        }
+    }
+
+    fun checkCanModify(review: Review, user: User?, password: String?) {
+        require((user != null) xor (password != null)) { "Either user or password must be provided, but not both" }
+
+        user?.let {
+            val reviewUser = review.user
+                ?: throw ServiceException("403-5", "회원 리뷰가 아니므로 회원 권한으로 수정할 수 없습니다.")
+            if (it.id != reviewUser.id)
+                throw ServiceException("403-4", "${review.id}번 리뷰 수정 권한이 없습니다.")
+        }
+
+        password?.let {
+            if (review.user != null)
+                throw ServiceException("403-6", "회원이 작성한 리뷰는 비밀번호로 수정할 수 없습니다.")
+            if (review.password != it)
+                throw ServiceException("400-1", "비밀번호가 일치하지 않습니다.")
+        }
+    }
+
 
     @Transactional
     fun createReview(

--- a/src/main/java/com/team04/back/domain/review/review/service/ReviewService.kt
+++ b/src/main/java/com/team04/back/domain/review/review/service/ReviewService.kt
@@ -49,40 +49,18 @@ class ReviewService(
 
     fun verifyPassword(review: Review, password: String): Boolean = review.password == password
 
-    fun checkCanDelete(review: Review, user: User?, password: String?) {
-        require((user != null) xor (password != null)) { "Either user or password must be provided, but not both" }
-
-        user?.let {
-            val reviewUser = review.user
-                ?: throw ServiceException("403-2", "회원 리뷰가 아니므로 회원 권한으로 삭제할 수 없습니다.")
-            if (it.id != reviewUser.id)
-                throw ServiceException("403-1", "${review.id}번 리뷰 삭제 권한이 없습니다.")
-        }
-
-        password?.let {
-            if (review.user != null)
-                throw ServiceException("403-3", "회원이 작성한 리뷰는 비밀번호로 삭제할 수 없습니다.")
-            if (review.password != it)
-                throw ServiceException("400-1", "비밀번호가 일치하지 않습니다.")
-        }
+    fun checkCanDelete(review: Review, user: User) {
+        val reviewUser = review.user
+            ?: throw ServiceException("403-2", "회원 리뷰가 아니므로 회원 권한으로 삭제할 수 없습니다.")
+        if (user.id != reviewUser.id)
+            throw ServiceException("403-1", "${review.id}번 리뷰 삭제 권한이 없습니다.")
     }
 
-    fun checkCanModify(review: Review, user: User?, password: String?) {
-        require((user != null) xor (password != null)) { "Either user or password must be provided, but not both" }
-
-        user?.let {
-            val reviewUser = review.user
-                ?: throw ServiceException("403-5", "회원 리뷰가 아니므로 회원 권한으로 수정할 수 없습니다.")
-            if (it.id != reviewUser.id)
-                throw ServiceException("403-4", "${review.id}번 리뷰 수정 권한이 없습니다.")
-        }
-
-        password?.let {
-            if (review.user != null)
-                throw ServiceException("403-6", "회원이 작성한 리뷰는 비밀번호로 수정할 수 없습니다.")
-            if (review.password != it)
-                throw ServiceException("400-1", "비밀번호가 일치하지 않습니다.")
-        }
+    fun checkCanModify(review: Review, user: User) {
+        val reviewUser = review.user
+            ?: throw ServiceException("403-4", "회원 리뷰가 아니므로 회원 권한으로 수정할 수 없습니다.")
+        if (user.id != reviewUser.id)
+            throw ServiceException("403-3", "${review.id}번 리뷰 수정 권한이 없습니다.")
     }
 
 

--- a/src/main/java/com/team04/back/domain/user/user/entity/User.java
+++ b/src/main/java/com/team04/back/domain/user/user/entity/User.java
@@ -1,7 +1,7 @@
 package com.team04.back.domain.user.user.entity;
 
+import com.team04.back.global.jpa.entity.BaseEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 
 // [원본 코드]
 //public class User {
@@ -12,8 +12,7 @@ import jakarta.persistence.Id;
 // 수정 사유: JPA 매핑 문제 해결 (ClothRecommendationHistory.user 참조 에러)
 // 추후 담당자가 확인 후 필요 시 수정 바람
 @Entity
-public class User {
-    @Id
+public class User extends BaseEntity {
     private Long dummy;
 
     public void setDummy(Long dummy) {

--- a/src/main/java/com/team04/back/domain/user/user/entity/User.java
+++ b/src/main/java/com/team04/back/domain/user/user/entity/User.java
@@ -2,6 +2,7 @@ package com.team04.back.domain.user.user.entity;
 
 import com.team04.back.global.jpa.entity.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 // [원본 코드]
 //public class User {
@@ -12,6 +13,7 @@ import jakarta.persistence.Entity;
 // 수정 사유: JPA 매핑 문제 해결 (ClothRecommendationHistory.user 참조 에러)
 // 추후 담당자가 확인 후 필요 시 수정 바람
 @Entity
+@Table(name = "`user`")
 public class User extends BaseEntity {
     private Long dummy;
 

--- a/src/main/java/com/team04/back/global/initData/BaseInitData.kt
+++ b/src/main/java/com/team04/back/global/initData/BaseInitData.kt
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
 import org.springframework.context.annotation.Profile
+import org.springframework.core.annotation.Order
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
@@ -30,6 +31,7 @@ class BaseInitData(
     private lateinit var self: BaseInitData
 
     @Bean
+    @Order(2)
     fun baseInitDataApplicationRunner(): ApplicationRunner {
         return ApplicationRunner { args: ApplicationArguments? ->
             self.work1()

--- a/src/main/java/com/team04/back/global/initData/BaseInitData.kt
+++ b/src/main/java/com/team04/back/global/initData/BaseInitData.kt
@@ -50,12 +50,12 @@ class BaseInitData(
         weatherService.save(weatherInfo4)
 
         reviewService.createReview(
-            "user1@test.com",
-            "1234",
-            "https://images.unsplash.com/photo-1658874761235-8d56cbd5da2d?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NHx8b290ZCUyMCVFQyU5NyVBQyVFQiVBNiU4NHxlbnwwfHwwfHx8MA%3D%3D",
-            "서울 여름 진짜 장난 아니네요;;",
-            "요즘 서울 진짜 미쳤어요... 햇빛이 너무 따갑고, 낮엔 밖에 나가면 숨이 턱턱 막혀요. 아침저녁은 그나마 나은데 낮 기온은 거의 37도 가까이 올라가네요. 에어컨 없으면 진짜 버티기 힘듭니다 ㅠㅠ",
-            "#한국여름#폭염주의",
+            email = "user1@test.com",
+            password = "1234",
+            imageUrl = "https://images.unsplash.com/photo-1658874761235-8d56cbd5da2d?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NHx8b290ZCUyMCVFQyU5NyVBQyVFQiVBNiU4NHxlbnwwfHwwfHx8MA%3D%3D",
+            title = "서울 여름 진짜 장난 아니네요;;",
+            sentence = "요즘 서울 진짜 미쳤어요... 햇빛이 너무 따갑고, 낮엔 밖에 나가면 숨이 턱턱 막혀요. 아침저녁은 그나마 나은데 낮 기온은 거의 37도 가까이 올라가네요. 에어컨 없으면 진짜 버티기 힘듭니다 ㅠㅠ",
+            tagString = "#한국여름#폭염주의",
             weatherInfo = weatherInfo1,
             clothList = listOf(
                 ClothItemReqBody(
@@ -86,34 +86,112 @@ class BaseInitData(
             )
         )
         reviewService.createReview(
-            "user2@test.com",
-            "1234",
-            "https://images.unsplash.com/photo-1638385583463-e3d424c22916?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MjB8fCVFQyU5RCVCQyVFQiVCMyVCOCUyMCVFQyU4MiVCRiVFRCU4RiVBQyVFQiVBMSU5QyUyMCVFQyVCRCU5NCVFQiU5NCU5NHxlbnwwfHwwfHx8MA%3D%3D",
-            "삿포로는 진짜 눈나라가 맞아요",
-            "삿포로의 겨울은 진짜 말 그대로 눈의 도시예요. 하루에도 몇 번씩 폭설이 내리고, 도로에 눈이 수북히 쌓여요. 체감 온도는 -15도까지도 떨어지고... 그래도 하얀 세상이 너무 예쁘고, 눈 오는 날 산책하는 재미도 있어요. 다만 옷 정말 단단히 입어야 합니다!",
-            "#일본#삿포로#겨울#눈폭탄",
+            email = "user2@test.com",
+            password = "1234",
+            imageUrl = "https://images.unsplash.com/photo-1638385583463-e3d424c22916?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MjB8fCVFQyU5RCVCQyVFQiVCMyVCOCUyMCVFQyU4MiVCRiVFRCU4RiVBQyVFQiVBMSU5QyUyMCVFQyVCRCU5NCVFQiU5NCU5NHxlbnwwfHwwfHx8MA%3D%3D",
+            title = "삿포로는 진짜 눈나라가 맞아요",
+            sentence = "삿포로의 겨울은 진짜 말 그대로 눈의 도시예요. 하루에도 몇 번씩 폭설이 내리고, 도로에 눈이 수북히 쌓여요. 체감 온도는 -15도까지도 떨어지고... 그래도 하얀 세상이 너무 예쁘고, 눈 오는 날 산책하는 재미도 있어요. 다만 옷 정말 단단히 입어야 합니다!",
+            tagString = "#일본#삿포로#겨울#눈폭탄",
             weatherInfo = weatherInfo2,
-            clothList = null
+            clothList = listOf(
+                ClothItemReqBody(
+                    clothName = ClothName.COAT,
+                    category = Category.TOP,
+                    style = Style.DATE_LOOK,
+                    isRecommend = true
+                ),
+                ClothItemReqBody(
+                    clothName = ClothName.JEANS,
+                    category = Category.BOTTOM,
+                    style = Style.DATE_LOOK,
+                    isRecommend = true
+                ),
+                ClothItemReqBody(
+                    clothName = ClothName.FUR_BOOTS,
+                    category = Category.SHOES,
+                    style = Style.DATE_LOOK,
+                    isRecommend = true
+                ),
+                ClothItemReqBody(
+                    clothName = ClothName.SCARF,
+                    category = Category.EXTRA,
+                    material = Material.WOOL,
+                    isRecommend = true
+                )
+            )
         )
         reviewService.createReview(
-            "user3@test.com",
-            "1234",
-            "https://images.unsplash.com/photo-1569789496053-095f2d6e3b05?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8OTR8fCVFRCU4QyU4QyVFQiVBNiVBQyUyMCVFQyU4MiVCMCVFQyVCMSU4NXxlbnwwfHwwfHx8MA%3D%3D",
-            "파리 여름밤 산책은 무조건이에요",
-            "파리에 처음 왔는데 여름 날씨가 너무 좋아요. 낮에는 약간 덥긴 한데 그늘에 들어가면 시원하고, 밤에는 선선해서 산책하기 딱이에요. 센 강 주변이나 에펠탑 근처 돌아다니다 보면 기분이 정말 좋아져요. 덕분에 하루에 만 보 넘게 걷고 있어요 :)",
-            "#파리#유럽여행#여름날씨#산책",
+            email = "user3@test.com",
+            password = "1234",
+            imageUrl = "https://images.unsplash.com/photo-1569789496053-095f2d6e3b05?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8OTR8fCVFRCU4QyU4QyVFQiVBNiVBQyUyMCVFQyU4MiVCMCVFQyVCMSU4NXxlbnwwfHwwfHx8MA%3D%3D",
+            title = "파리 여름밤 산책은 무조건이에요",
+            sentence = "파리에 처음 왔는데 여름 날씨가 너무 좋아요. 낮에는 약간 덥긴 한데 그늘에 들어가면 시원하고, 밤에는 선선해서 산책하기 딱이에요. 센 강 주변이나 에펠탑 근처 돌아다니다 보면 기분이 정말 좋아져요. 덕분에 하루에 만 보 넘게 걷고 있어요 :)",
+            tagString = "#파리#유럽여행#여름날씨#산책",
             weatherInfo = weatherInfo3,
-            clothList = null
+            clothList = listOf(
+                ClothItemReqBody(
+                    clothName = ClothName.T_SHIRT,
+                    category = Category.TOP,
+                    style = Style.CASUAL_DAILY,
+                    material = Material.COTTON,
+                    isRecommend = true
+                ),
+                ClothItemReqBody(
+                    clothName = ClothName.CARDIGAN,
+                    category = Category.TOP,
+                    style = Style.CASUAL_DAILY,
+                    material = Material.COTTON,
+                    isRecommend = true
+                ),
+                ClothItemReqBody(
+                    clothName = ClothName.CHINOS,
+                    category = Category.BOTTOM,
+                    style = Style.CASUAL_DAILY,
+                    isRecommend = true
+                ),
+                ClothItemReqBody(
+                    clothName = ClothName.ATHLETIC_SHOES,
+                    category = Category.SHOES,
+                    style = Style.CASUAL_DAILY,
+                    isRecommend = true
+                )
+            )
         )
         reviewService.createReview(
-            "user4@test.com",
-            "1234",
-            "https://images.unsplash.com/photo-1518090753814-263ac71fc863?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8M3x8JUVCJTlGJUIwJUVCJThEJTk4JTIwJUVDJTlBJUIwJUVDJTgyJUIwfGVufDB8fDB8fHww",
-            "런던은 정말 자주 비가 오네요... 우산 필수입니다 ☔",
-            "런던 가을비는 정말 자주 오는 편이네요. 하루에도 몇 번씩 비가 왔다 그쳤다 하고, 흐린 날이 많아요. 덕분에 분위기는 정말 좋지만, 외출할 때마다 우산은 필수예요. 현지 사람들은 그냥 맞고 다니던데... 전 그건 아직 무리네요 ㅎㅎ",
-            "#런던#가을비#우산#영국날씨",
+            email = "user4@test.com",
+            password = "1234",
+            imageUrl = "https://images.unsplash.com/photo-1518090753814-263ac71fc863?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8M3x8JUVCJTlGJUIwJUVCJThEJTk4JTIwJUVDJTlBJUIwJUVDJTgyJUIwfGVufDB8fDB8fHww",
+            title = "런던은 정말 자주 비가 오네요... 우산 필수입니다 ☔",
+            sentence = "런던 가을비는 정말 자주 오는 편이네요. 하루에도 몇 번씩 비가 왔다 그쳤다 하고, 흐린 날이 많아요. 덕분에 분위기는 정말 좋지만, 외출할 때마다 우산은 필수예요. 현지 사람들은 그냥 맞고 다니던데... 전 그건 아직 무리네요 ㅎㅎ",
+            tagString = "#런던#가을비#우산#영국날씨",
             weatherInfo = weatherInfo4,
-            clothList = null
+            clothList = listOf(
+                ClothItemReqBody(
+                    clothName = ClothName.COAT,
+                    category = Category.TOP,
+                    style = Style.CASUAL_DAILY,
+                    material = Material.WOOL,
+                    isRecommend = true
+                ),
+                ClothItemReqBody(
+                    clothName = ClothName.SLACKS,
+                    category = Category.BOTTOM,
+                    style = Style.CASUAL_DAILY,
+                    material = Material.POLYESTER,
+                    isRecommend = true
+                ),
+                ClothItemReqBody(
+                    clothName = ClothName.SNEAKERS,
+                    category = Category.SHOES,
+                    style = Style.CASUAL_DAILY,
+                    isRecommend = false
+                ),
+                ClothItemReqBody(
+                    clothName = ClothName.UMBRELLA,
+                    category = Category.EXTRA,
+                    isRecommend = true
+                )
+            )
         )
 
         println("초기 데이터가 생성되었습니다.")

--- a/src/main/java/com/team04/back/global/initData/BaseInitData.kt
+++ b/src/main/java/com/team04/back/global/initData/BaseInitData.kt
@@ -56,8 +56,8 @@ class BaseInitData(
             "서울 여름 진짜 장난 아니네요;;",
             "요즘 서울 진짜 미쳤어요... 햇빛이 너무 따갑고, 낮엔 밖에 나가면 숨이 턱턱 막혀요. 아침저녁은 그나마 나은데 낮 기온은 거의 37도 가까이 올라가네요. 에어컨 없으면 진짜 버티기 힘듭니다 ㅠㅠ",
             "#한국여름#폭염주의",
-            weatherInfo1,
-            listOf(
+            weatherInfo = weatherInfo1,
+            clothList = listOf(
                 ClothItemReqBody(
                     clothName = ClothName.FUNCTIONAL_T_SHIRT,
                     category = Category.TOP,
@@ -92,8 +92,8 @@ class BaseInitData(
             "삿포로는 진짜 눈나라가 맞아요",
             "삿포로의 겨울은 진짜 말 그대로 눈의 도시예요. 하루에도 몇 번씩 폭설이 내리고, 도로에 눈이 수북히 쌓여요. 체감 온도는 -15도까지도 떨어지고... 그래도 하얀 세상이 너무 예쁘고, 눈 오는 날 산책하는 재미도 있어요. 다만 옷 정말 단단히 입어야 합니다!",
             "#일본#삿포로#겨울#눈폭탄",
-            weatherInfo2,
-            null
+            weatherInfo = weatherInfo2,
+            clothList = null
         )
         reviewService.createReview(
             "user3@test.com",
@@ -102,8 +102,8 @@ class BaseInitData(
             "파리 여름밤 산책은 무조건이에요",
             "파리에 처음 왔는데 여름 날씨가 너무 좋아요. 낮에는 약간 덥긴 한데 그늘에 들어가면 시원하고, 밤에는 선선해서 산책하기 딱이에요. 센 강 주변이나 에펠탑 근처 돌아다니다 보면 기분이 정말 좋아져요. 덕분에 하루에 만 보 넘게 걷고 있어요 :)",
             "#파리#유럽여행#여름날씨#산책",
-            weatherInfo3,
-            null
+            weatherInfo = weatherInfo3,
+            clothList = null
         )
         reviewService.createReview(
             "user4@test.com",
@@ -112,8 +112,8 @@ class BaseInitData(
             "런던은 정말 자주 비가 오네요... 우산 필수입니다 ☔",
             "런던 가을비는 정말 자주 오는 편이네요. 하루에도 몇 번씩 비가 왔다 그쳤다 하고, 흐린 날이 많아요. 덕분에 분위기는 정말 좋지만, 외출할 때마다 우산은 필수예요. 현지 사람들은 그냥 맞고 다니던데... 전 그건 아직 무리네요 ㅎㅎ",
             "#런던#가을비#우산#영국날씨",
-            weatherInfo4,
-            null
+            weatherInfo = weatherInfo4,
+            clothList = null
         )
 
         println("초기 데이터가 생성되었습니다.")

--- a/src/main/java/com/team04/back/global/initData/ClothInitData.kt
+++ b/src/main/java/com/team04/back/global/initData/ClothInitData.kt
@@ -1,20 +1,20 @@
 package com.team04.back.global.initData
 
+import com.team04.back.domain.cloth.cloth.entity.ClothInfo.Companion.create
+import com.team04.back.domain.cloth.cloth.enums.Category
 import com.team04.back.domain.cloth.cloth.enums.Category.*
-import com.team04.back.domain.cloth.cloth.enums.ClothName
 import com.team04.back.domain.cloth.cloth.enums.ClothName.*
 import com.team04.back.domain.cloth.cloth.enums.Material.*
 import com.team04.back.domain.cloth.cloth.enums.Style.*
 import com.team04.back.domain.cloth.cloth.service.ClothService
-import com.team04.back.domain.weather.weather.enums.Weather
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
+import org.springframework.core.annotation.Order
 import org.springframework.transaction.annotation.Transactional
-import com.team04.back.domain.cloth.cloth.entity.ClothInfo.Companion.create as createCloth
 
 @Configuration
 class ClothInitData(
@@ -25,6 +25,7 @@ class ClothInitData(
     private lateinit var self: ClothInitData
 
     @Bean
+    @Order(1)
     fun clothInitDataRunner(): ApplicationRunner {
         return ApplicationRunner { args: ApplicationArguments -> self.insertData() }
     }
@@ -35,118 +36,126 @@ class ClothInitData(
 
         // === ClothInfo Style별 기본 데이터 ===
         // CASUAL_DAILY - Cold
-        clothService.save(createCloth(SWEATER, "https://i.postimg.cc/vZvNvYP5/cold-shirts.png", TOP, CASUAL_DAILY, WOOL, -10.0, 9.9)) // "cold_wool_warm_sweater"
-        clothService.save(createCloth(CARGO_PANTS, "https://i.postimg.cc/vmNXPc5x/cold-pants.png", BOTTOM, CASUAL_DAILY, WOOL, -10.0, 9.9)) // "cold_wool_warm_pants"
-        clothService.save(createCloth(LEATHER_BOOTS, "https://i.postimg.cc/65Xc1s4c/cold-shoes.png", SHOES, CASUAL_DAILY, LEATHER, -10.0, 9.9)) // "cold_leather_winter_boots"
+        clothService.save(create(SWEATER, "https://i.postimg.cc/vZvNvYP5/cold-shirts.png", TOP, CASUAL_DAILY, WOOL, -10.0, 9.9)) // "cold_wool_warm_sweater"
+        clothService.save(create(CARGO_PANTS, "https://i.postimg.cc/vmNXPc5x/cold-pants.png", BOTTOM, CASUAL_DAILY, WOOL, -10.0, 9.9)) // "cold_wool_warm_pants"
+        clothService.save(create(LEATHER_BOOTS, "https://i.postimg.cc/65Xc1s4c/cold-shoes.png", SHOES, CASUAL_DAILY, LEATHER, -10.0, 9.9)) // "cold_leather_winter_boots"
 
         // CASUAL_DAILY - Warm
-        clothService.save(createCloth(DENIM_JACKET, "https://i.postimg.cc/sgfcspcZ/warm-shirts.png", TOP, CASUAL_DAILY, DENIM, 10.0, 20.0)) // "warm_denim_light_jacket"
-        clothService.save(createCloth(JEANS, "https://i.postimg.cc/HLV97dFY/warm-pants.png", BOTTOM, CASUAL_DAILY, DENIM, 10.0, 20.0)) // "warm_denim_jeans"
-        clothService.save(createCloth(SNEAKERS, "https://i.postimg.cc/SRp658RR/warm-shoes.png", SHOES, CASUAL_DAILY, null, 10.0, 20.0)) // "warm_canvas_sneakers"
+        clothService.save(create(DENIM_JACKET, "https://i.postimg.cc/sgfcspcZ/warm-shirts.png", TOP, CASUAL_DAILY, DENIM, 10.0, 20.0)) // "warm_denim_light_jacket"
+        clothService.save(create(JEANS, "https://i.postimg.cc/HLV97dFY/warm-pants.png", BOTTOM, CASUAL_DAILY, DENIM, 10.0, 20.0)) // "warm_denim_jeans"
+        clothService.save(create(SNEAKERS, "https://i.postimg.cc/SRp658RR/warm-shoes.png", SHOES, CASUAL_DAILY, null, 10.0, 20.0)) // "warm_canvas_sneakers"
 
         // CASUAL_DAILY - Hot
-        clothService.save(createCloth(T_SHIRT, "https://i.postimg.cc/h49bmCZd/hot-shirts.png", TOP, CASUAL_DAILY, COTTON, 20.1, 50.0)) // "hot_cotton_t_shirt"
-        clothService.save(createCloth(SHORTS, "https://i.postimg.cc/FsNbVjwn/hot-pant.png", BOTTOM, CASUAL_DAILY, COTTON, 20.1, 50.0)) // "hot_cotton_shorts"
-        clothService.save(createCloth(SANDALS, "https://i.postimg.cc/63CRd3cX/hot-shoes.png", SHOES, CASUAL_DAILY, null, 20.1, 50.0)) // "hot_synthetic_sandals"
+        clothService.save(create(T_SHIRT, "https://i.postimg.cc/h49bmCZd/hot-shirts.png", TOP, CASUAL_DAILY, COTTON, 20.1, 50.0)) // "hot_cotton_t_shirt"
+        clothService.save(create(SHORTS, "https://i.postimg.cc/FsNbVjwn/hot-pant.png", BOTTOM, CASUAL_DAILY, COTTON, 20.1, 50.0)) // "hot_cotton_shorts"
+        clothService.save(create(SANDALS, "https://i.postimg.cc/63CRd3cX/hot-shoes.png", SHOES, CASUAL_DAILY, null, 20.1, 50.0)) // "hot_synthetic_sandals"
 
         // FORMAL_OFFICE - Cold
-        clothService.save(createCloth(SWEATER,"https://i.postimg.cc/1XPFMQ7N/cold-shirts.png", TOP, FORMAL_OFFICE, WOOL, -10.0, 9.9)) // "cold_wool_sweater"
-        clothService.save(createCloth(JEANS, "https://i.postimg.cc/DwmXx565/cold-pants.png", BOTTOM, FORMAL_OFFICE, WOOL, -10.0, 9.9)) // "cold_wool_dress_pants"
-        clothService.save(createCloth(LEATHER_BOOTS, "https://i.postimg.cc/Dwt8Bh8y/cold-shoes.png", SHOES, FORMAL_OFFICE, LEATHER, -10.0, 9.9)) // "cold_leather_boots"
+        clothService.save(create(SWEATER,"https://i.postimg.cc/1XPFMQ7N/cold-shirts.png", TOP, FORMAL_OFFICE, WOOL, -10.0, 9.9)) // "cold_wool_sweater"
+        clothService.save(create(JEANS, "https://i.postimg.cc/DwmXx565/cold-pants.png", BOTTOM, FORMAL_OFFICE, WOOL, -10.0, 9.9)) // "cold_wool_dress_pants"
+        clothService.save(create(LEATHER_BOOTS, "https://i.postimg.cc/Dwt8Bh8y/cold-shoes.png", SHOES, FORMAL_OFFICE, LEATHER, -10.0, 9.9)) // "cold_leather_boots"
 
         // FORMAL_OFFICE - Warm
-        clothService.save(createCloth(BLAZER, "https://i.postimg.cc/fLskQvcG/warm-shirts.png", TOP, FORMAL_OFFICE, WOOL, 10.0, 20.0)) // "warm_blend_blazer"
-        clothService.save(createCloth(CHINOS, "https://i.postimg.cc/J06hJVf8/warm-pants.png", BOTTOM, FORMAL_OFFICE, COTTON, 10.0, 20.0)) // "warm_cotton_chinos"
-        clothService.save(createCloth(OXFORDS, "https://i.postimg.cc/9F00209Q/warm-shoes.png", SHOES, FORMAL_OFFICE, LEATHER, 10.0, 20.0)) // "warm_leather_oxfords"
+        clothService.save(create(BLAZER, "https://i.postimg.cc/fLskQvcG/warm-shirts.png", TOP, FORMAL_OFFICE, WOOL, 10.0, 20.0)) // "warm_blend_blazer"
+        clothService.save(create(CHINOS, "https://i.postimg.cc/J06hJVf8/warm-pants.png", BOTTOM, FORMAL_OFFICE, COTTON, 10.0, 20.0)) // "warm_cotton_chinos"
+        clothService.save(create(OXFORDS, "https://i.postimg.cc/9F00209Q/warm-shoes.png", SHOES, FORMAL_OFFICE, LEATHER, 10.0, 20.0)) // "warm_leather_oxfords"
 
         // FORMAL_OFFICE - Hot
-        clothService.save(createCloth(DRESS_SHIRT, "https://i.postimg.cc/MGSznpnR/hot-shirts.png", TOP, FORMAL_OFFICE, COTTON, 20.1, 50.0)) // "hot_cotton_dress_shirt"
-        clothService.save(createCloth(SLACKS, "https://i.postimg.cc/wBQgLYNr/hot-pants.png", BOTTOM, FORMAL_OFFICE, POLYESTER, 20.1, 50.0)) // "hot_polyester_slacks"
-        clothService.save(createCloth(LOAFERS, "https://i.postimg.cc/6qm9qVZ5/hot-shoes.png", SHOES, FORMAL_OFFICE, LEATHER, 20.1, 50.0)) // "hot_leather_loafers"
+        clothService.save(create(DRESS_SHIRT, "https://i.postimg.cc/MGSznpnR/hot-shirts.png", TOP, FORMAL_OFFICE, COTTON, 20.1, 50.0)) // "hot_cotton_dress_shirt"
+        clothService.save(create(SLACKS, "https://i.postimg.cc/wBQgLYNr/hot-pants.png", BOTTOM, FORMAL_OFFICE, POLYESTER, 20.1, 50.0)) // "hot_polyester_slacks"
+        clothService.save(create(LOAFERS, "https://i.postimg.cc/6qm9qVZ5/hot-shoes.png", SHOES, FORMAL_OFFICE, LEATHER, 20.1, 50.0)) // "hot_leather_loafers"
 
         // OUTDOOR - Cold
-        clothService.save(createCloth(PADDING, "https://i.postimg.cc/sxvrkBLF/cold-shirts.png", TOP, OUTDOOR, WOOL, -10.0, 9.9)) // "cold_wool_thermal_jacket"
-        clothService.save(createCloth(SKI_PANTS, "https://i.postimg.cc/nc9xTD7B/cold-pants.png", BOTTOM, OUTDOOR, WOOL, -10.0, 9.9)) // "cold_wool_thermal_pants"
-        clothService.save(createCloth(HIKING_SHOES, "https://i.postimg.cc/cLQSGGFJ/cold-shoes.png", SHOES, OUTDOOR, LEATHER, -10.0, 9.9)) // "cold_leather_hiking_boots"
+        clothService.save(create(PADDING, "https://i.postimg.cc/sxvrkBLF/cold-shirts.png", TOP, OUTDOOR, WOOL, -10.0, 9.9)) // "cold_wool_thermal_jacket"
+        clothService.save(create(SKI_PANTS, "https://i.postimg.cc/nc9xTD7B/cold-pants.png", BOTTOM, OUTDOOR, WOOL, -10.0, 9.9)) // "cold_wool_thermal_pants"
+        clothService.save(create(HIKING_SHOES, "https://i.postimg.cc/cLQSGGFJ/cold-shoes.png", SHOES, OUTDOOR, LEATHER, -10.0, 9.9)) // "cold_leather_hiking_boots"
 
         // OUTDOOR - Warm
-        clothService.save(createCloth(WINDBREAKER, "https://i.postimg.cc/nVjVSgfX/warm-shirts.png", TOP, OUTDOOR, NYLON, 10.0, 20.0)) // "warm_nylon_windbreaker"
-        clothService.save(createCloth(CARGO_PANTS, "https://i.postimg.cc/rzXPfKXN/warm-pants.png", BOTTOM, OUTDOOR, COTTON, 10.0, 20.0)) // "warm_cotton_cargo_pants"
-        clothService.save(createCloth(SNEAKERS, "https://i.postimg.cc/8k2p24Tt/warm-shoes.png", SHOES, OUTDOOR, null, 10.0, 20.0)) // "warm_mesh_trail_sneakers"
+        clothService.save(create(WINDBREAKER, "https://i.postimg.cc/nVjVSgfX/warm-shirts.png", TOP, OUTDOOR, NYLON, 10.0, 20.0)) // "warm_nylon_windbreaker"
+        clothService.save(create(CARGO_PANTS, "https://i.postimg.cc/rzXPfKXN/warm-pants.png", BOTTOM, OUTDOOR, COTTON, 10.0, 20.0)) // "warm_cotton_cargo_pants"
+        clothService.save(create(SNEAKERS, "https://i.postimg.cc/8k2p24Tt/warm-shoes.png", SHOES, OUTDOOR, null, 10.0, 20.0)) // "warm_mesh_trail_sneakers"
 
         // OUTDOOR - Hot
-        clothService.save(createCloth(FUNCTIONAL_T_SHIRT, "https://i.postimg.cc/2yqsHsqr/hot-shirts.png", TOP, OUTDOOR, POLYESTER, 20.1, 50.0)) // "hot_polyester_moisture_wicking_shirt"
-        clothService.save(createCloth(SHORTS, "https://i.postimg.cc/0yGLHdNM/hot-pants.png", BOTTOM, OUTDOOR, POLYESTER, 20.1, 50.0)) // "hot_polyester_shorts"
-        clothService.save(createCloth(SANDALS, "https://i.postimg.cc/vBKj600j/hot-shoes.png", SHOES, OUTDOOR, null, 20.1, 50.0)) // "hot_synthetic_sandals"
+        clothService.save(create(FUNCTIONAL_T_SHIRT, "https://i.postimg.cc/2yqsHsqr/hot-shirts.png", TOP, OUTDOOR, POLYESTER, 20.1, 50.0)) // "hot_polyester_moisture_wicking_shirt"
+        clothService.save(create(SHORTS, "https://i.postimg.cc/0yGLHdNM/hot-pants.png", BOTTOM, OUTDOOR, POLYESTER, 20.1, 50.0)) // "hot_polyester_shorts"
+        clothService.save(create(SANDALS, "https://i.postimg.cc/vBKj600j/hot-shoes.png", SHOES, OUTDOOR, null, 20.1, 50.0)) // "hot_synthetic_sandals"
 
         // DATE_LOOK - Cold
-        clothService.save(createCloth(SWEATER, "https://i.postimg.cc/dtcFH09f/cold-shirts.png", TOP, DATE_LOOK, WOOL, -10.0, 9.9)) // "cold_wool_knit_sweater"
-        clothService.save(createCloth(CORDUROY_PANTS, "https://i.postimg.cc/9QJjQYj3/cold-pants.png", BOTTOM, DATE_LOOK, CORDUROY, -10.0, 9.9)) // "cold_corduroy_pants"
-        clothService.save(createCloth(ANKLE_BOOTS, "https://i.postimg.cc/FKzXdk9Y/cold-shoes.png", SHOES, DATE_LOOK, LEATHER, -10.0, 9.9)) // "cold_leather_ankle_boots"
+        clothService.save(create(SWEATER, "https://i.postimg.cc/dtcFH09f/cold-shirts.png", TOP, DATE_LOOK, WOOL, -10.0, 9.9)) // "cold_wool_knit_sweater"
+        clothService.save(create(CORDUROY_PANTS, "https://i.postimg.cc/9QJjQYj3/cold-pants.png", BOTTOM, DATE_LOOK, CORDUROY, -10.0, 9.9)) // "cold_corduroy_pants"
+        clothService.save(create(ANKLE_BOOTS, "https://i.postimg.cc/FKzXdk9Y/cold-shoes.png", SHOES, DATE_LOOK, LEATHER, -10.0, 9.9)) // "cold_leather_ankle_boots"
 
         // DATE_LOOK - Warm
-        clothService.save(createCloth(CARDIGAN, "https://i.postimg.cc/NMrhbh2Y/warm-shirts.png", TOP, DATE_LOOK, COTTON, 10.0, 20.0)) // "warm_cotton_cardigan"
-        clothService.save(createCloth(JEANS, "https://i.postimg.cc/9X7VY9yT/warm-pants.png", BOTTOM, DATE_LOOK, DENIM, 10.0, 20.0)) // "warm_denim_slim_jeans"
-        clothService.save(createCloth(FLATS, "https://i.postimg.cc/ryxXrkLN/warm-shoes.png", SHOES, DATE_LOOK, LEATHER, 10.0, 20.0)) // "warm_leather_ballet_flats"
+        clothService.save(create(CARDIGAN, "https://i.postimg.cc/NMrhbh2Y/warm-shirts.png", TOP, DATE_LOOK, COTTON, 10.0, 20.0)) // "warm_cotton_cardigan"
+        clothService.save(create(JEANS, "https://i.postimg.cc/9X7VY9yT/warm-pants.png", BOTTOM, DATE_LOOK, DENIM, 10.0, 20.0)) // "warm_denim_slim_jeans"
+        clothService.save(create(FLATS, "https://i.postimg.cc/ryxXrkLN/warm-shoes.png", SHOES, DATE_LOOK, LEATHER, 10.0, 20.0)) // "warm_leather_ballet_flats"
 
         // DATE_LOOK - Hot
-        clothService.save(createCloth(BLOUSE, "https://i.postimg.cc/521x0tYz/hot-shirts.png", TOP, DATE_LOOK, POLYESTER, 20.1, 50.0)) // "hot_polyester_floral_blouse"
-        clothService.save(createCloth(SKIRT, "https://i.postimg.cc/3NmTrM39/hot-pants.png", BOTTOM, DATE_LOOK, POLYESTER, 20.1, 50.0)) // "hot_polyester_skirt"
-        clothService.save(createCloth(HEELS, "https://i.postimg.cc/XY8ny0dz/hot-shoes.png", SHOES, DATE_LOOK, LEATHER, 20.1, 50.0)) // "hot_leather_open_toe_heels"
+        clothService.save(create(BLOUSE, "https://i.postimg.cc/521x0tYz/hot-shirts.png", TOP, DATE_LOOK, POLYESTER, 20.1, 50.0)) // "hot_polyester_floral_blouse"
+        clothService.save(create(SKIRT, "https://i.postimg.cc/3NmTrM39/hot-pants.png", BOTTOM, DATE_LOOK, POLYESTER, 20.1, 50.0)) // "hot_polyester_skirt"
+        clothService.save(create(HEELS, "https://i.postimg.cc/XY8ny0dz/hot-shoes.png", SHOES, DATE_LOOK, LEATHER, 20.1, 50.0)) // "hot_leather_open_toe_heels"
 
         // === ExtraCloth 저장 ===
-//        clothService.save(ExtraCloth.create(clothName = ClothName.SHORTS, imageUrl = "https://i.postimg.cc/fbzgqVkM/image.png", weather = Weather.HEAT_WAVE))
-//        clothService.save(ExtraCloth.create(clothName = ClothName.JEANS, imageUrl = "https://i.postimg.cc/RFm813m1/image.png", weather = Weather.MODERATE_RAIN))
-//        clothService.save(ExtraCloth.create(clothName = ClothName.CARDIGAN, imageUrl = "https://i.postimg.cc/RFm813m1/image.png", weather = Weather.SNOW))
-//        clothService.save(ExtraCloth.create(clothName = ClothName.CHINOS, imageUrl = "https://i.postimg.cc/Sx7c2jZb/image.png", weather = Weather.MIST))
+        clothService.save(create(HAT, "https://i.postimg.cc/DytgTxVq/hat.png", Category.EXTRA, null, null, null, null)) // weather = Weather.HEAT_WAVE
+        clothService.save(create(CAP, "https://i.postimg.cc/ZYDkrz34/cap.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(BEANIE, "https://i.postimg.cc/GhBWKgJY/beanie.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(SCARF, "https://i.postimg.cc/XXMQQL4c/scarf.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(GLOVES, "https://i.postimg.cc/T15tVFM3/gloves.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(BELT, "https://i.postimg.cc/R0srGk87/belt.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(BAG, "https://i.postimg.cc/Y9Z5B1tj/bag.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(BACKPACK, "https://i.postimg.cc/L6dcyByb/backpack.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(CROSSBODY_BAG, "https://i.postimg.cc/13sLSR10/crossbody-bag.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(SUNGLASSES, "https://i.postimg.cc/6QQg7H3y/sunglasses.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(UMBRELLA, "https://i.postimg.cc/PqFc1mpK/umbrella.png", Category.EXTRA, null, null, null, null)) // weather = Weather.MODERATE_RAIN, Weather.SNOW
+        clothService.save(create(MASK, "https://i.postimg.cc/9M6nnCB7/mask.png", Category.EXTRA, null, null, null, null)) // weather = Weather.MIST
 
 
         // === ClothInfo ClothName별 기본 데이터 ===
         // TOP
-        clothService.save(createCloth(T_SHIRT, "https://i.postimg.cc/GhZ3xc7G/t-shirt.png", TOP, null, null, null, null))
-        clothService.save(createCloth(SWEATSHIRT, "https://i.postimg.cc/d0qbjN96/sweatshirt.png", TOP, null, null, null, null))
-        clothService.save(createCloth(HOODIE, "https://i.postimg.cc/QMHRz9RK/hoodie.png", TOP, null, null, null, null))
-        clothService.save(createCloth(SHIRT, "https://i.postimg.cc/YqMTHy5H/shirt.png", TOP, null, null, null, null))
-        clothService.save(createCloth(DRESS_SHIRT, "https://i.postimg.cc/NM6JJn1L/dress-shirt.png", TOP, null, null, null, null))
-        clothService.save(createCloth(BLOUSE, "https://i.postimg.cc/VvVtDhMC/blouse.png", TOP, null, null, null, null))
-        clothService.save(createCloth(SWEATER, "https://i.postimg.cc/tgjxSW12/sweater.png", TOP, null, null, null, null))
-        clothService.save(createCloth(CARDIGAN, "https://i.postimg.cc/GhvYkXtH/cardigan.png", TOP, null, null, null, null))
-        clothService.save(createCloth(COAT, "https://i.postimg.cc/g2NxDQWk/coat.png", TOP, null, null, null, null))
-        clothService.save(createCloth(JACKET, "https://i.postimg.cc/8z1f1VGN/jacket.png", TOP, null, null, null, null))
-        clothService.save(createCloth(LEATHER_JACKET, "https://i.postimg.cc/ncw8GGWf/leather-jacket.png", TOP, null, null, null, null))
-        clothService.save(createCloth(DENIM_JACKET, "https://i.postimg.cc/k53pT1Fz/denim-jacket.png", TOP, null, null, null, null))
-        clothService.save(createCloth(BLAZER, "https://i.postimg.cc/T1F9p1tF/blazer.png", TOP, null, null, null, null))
-        clothService.save(createCloth(PADDING, "https://i.postimg.cc/qBSXctGZ/padding.png", TOP, null, null, null, null))
-        clothService.save(createCloth(VEST, "https://i.postimg.cc/gjZhtDKt/vest.png", TOP, null, null, null, null))
-        clothService.save(createCloth(WINDBREAKER, "https://i.postimg.cc/3JLhbTd6/jacket.png", TOP, null, null, null, null))
-        clothService.save(createCloth(FUNCTIONAL_T_SHIRT, "https://i.postimg.cc/QMk1RZyL/functional-t-shirt.png", TOP, null, null, null, null))
+        clothService.save(create(T_SHIRT, "https://i.postimg.cc/GhZ3xc7G/t-shirt.png", TOP, null, null, null, null))
+        clothService.save(create(SWEATSHIRT, "https://i.postimg.cc/d0qbjN96/sweatshirt.png", TOP, null, null, null, null))
+        clothService.save(create(HOODIE, "https://i.postimg.cc/QMHRz9RK/hoodie.png", TOP, null, null, null, null))
+        clothService.save(create(SHIRT, "https://i.postimg.cc/YqMTHy5H/shirt.png", TOP, null, null, null, null))
+        clothService.save(create(DRESS_SHIRT, "https://i.postimg.cc/NM6JJn1L/dress-shirt.png", TOP, null, null, null, null))
+        clothService.save(create(BLOUSE, "https://i.postimg.cc/VvVtDhMC/blouse.png", TOP, null, null, null, null))
+        clothService.save(create(SWEATER, "https://i.postimg.cc/tgjxSW12/sweater.png", TOP, null, null, null, null))
+        clothService.save(create(CARDIGAN, "https://i.postimg.cc/GhvYkXtH/cardigan.png", TOP, null, null, null, null))
+        clothService.save(create(COAT, "https://i.postimg.cc/g2NxDQWk/coat.png", TOP, null, null, null, null))
+        clothService.save(create(JACKET, "https://i.postimg.cc/8z1f1VGN/jacket.png", TOP, null, null, null, null))
+        clothService.save(create(LEATHER_JACKET, "https://i.postimg.cc/ncw8GGWf/leather-jacket.png", TOP, null, null, null, null))
+        clothService.save(create(DENIM_JACKET, "https://i.postimg.cc/k53pT1Fz/denim-jacket.png", TOP, null, null, null, null))
+        clothService.save(create(BLAZER, "https://i.postimg.cc/T1F9p1tF/blazer.png", TOP, null, null, null, null))
+        clothService.save(create(PADDING, "https://i.postimg.cc/qBSXctGZ/padding.png", TOP, null, null, null, null))
+        clothService.save(create(VEST, "https://i.postimg.cc/gjZhtDKt/vest.png", TOP, null, null, null, null))
+        clothService.save(create(WINDBREAKER, "https://i.postimg.cc/3JLhbTd6/jacket.png", TOP, null, null, null, null))
+        clothService.save(create(FUNCTIONAL_T_SHIRT, "https://i.postimg.cc/QMk1RZyL/functional-t-shirt.png", TOP, null, null, null, null))
 
         // BOTTOM
-        clothService.save(createCloth(JEANS, "https://i.postimg.cc/rwSjHTJT/jeans.png", BOTTOM, null, null, null, null))
-        clothService.save(createCloth(SLACKS, "https://i.postimg.cc/bYDBRKKy/slacks.png", BOTTOM, null, null, null, null))
-        clothService.save(createCloth(SHORTS, "https://i.postimg.cc/448Zqk3r/shorts.png", BOTTOM, null, null, null, null))
-        clothService.save(createCloth(SKIRT, "https://i.postimg.cc/3wZYh9pq/skirt.png", BOTTOM, null, null, null, null))
-        clothService.save(createCloth(JOGGER_PANTS, "https://i.postimg.cc/Hn9hcPWG/jogger-pants.png", BOTTOM, null, null, null, null))
-        clothService.save(createCloth(TRACK_PANTS, "https://i.postimg.cc/vmdMVCbT/track-pants.png", BOTTOM, null, null, null, null))
-        clothService.save(createCloth(LEGGINGS, "https://i.postimg.cc/3NkkWzFN/leggings.png", BOTTOM, null, null, null, null))
-        clothService.save(createCloth(CARGO_PANTS, "https://i.postimg.cc/9f3sLZv8/cargo-pants.png", BOTTOM, null, null, null, null))
-        clothService.save(createCloth(CORDUROY_PANTS, "https://i.postimg.cc/g2LfyNBL/corduroy-pants.png", BOTTOM, null, null, null, null))
-        clothService.save(createCloth(CHINOS, "https://i.postimg.cc/R0QpG81h/chinos.png", BOTTOM, null, null, null, null))
-        clothService.save(createCloth(SKI_PANTS, "https://i.postimg.cc/02y6NJXB/ski-pants.png", BOTTOM, null, null, null, null))
+        clothService.save(create(JEANS, "https://i.postimg.cc/rwSjHTJT/jeans.png", BOTTOM, null, null, null, null))
+        clothService.save(create(SLACKS, "https://i.postimg.cc/bYDBRKKy/slacks.png", BOTTOM, null, null, null, null))
+        clothService.save(create(SHORTS, "https://i.postimg.cc/448Zqk3r/shorts.png", BOTTOM, null, null, null, null))
+        clothService.save(create(SKIRT, "https://i.postimg.cc/3wZYh9pq/skirt.png", BOTTOM, null, null, null, null))
+        clothService.save(create(JOGGER_PANTS, "https://i.postimg.cc/Hn9hcPWG/jogger-pants.png", BOTTOM, null, null, null, null))
+        clothService.save(create(TRACK_PANTS, "https://i.postimg.cc/vmdMVCbT/track-pants.png", BOTTOM, null, null, null, null))
+        clothService.save(create(LEGGINGS, "https://i.postimg.cc/3NkkWzFN/leggings.png", BOTTOM, null, null, null, null))
+        clothService.save(create(CARGO_PANTS, "https://i.postimg.cc/9f3sLZv8/cargo-pants.png", BOTTOM, null, null, null, null))
+        clothService.save(create(CORDUROY_PANTS, "https://i.postimg.cc/g2LfyNBL/corduroy-pants.png", BOTTOM, null, null, null, null))
+        clothService.save(create(CHINOS, "https://i.postimg.cc/R0QpG81h/chinos.png", BOTTOM, null, null, null, null))
+        clothService.save(create(SKI_PANTS, "https://i.postimg.cc/02y6NJXB/ski-pants.png", BOTTOM, null, null, null, null))
 
         // SHOES
-        clothService.save(createCloth(SNEAKERS, "https://i.postimg.cc/1zkQQTYs/sneakers.png", SHOES, null, null, null, null))
-        clothService.save(createCloth(ATHLETIC_SHOES, "https://i.postimg.cc/Bbg92vZn/athletic-shoes.png", SHOES, null, null, null, null))
-        clothService.save(createCloth(FLATS, "https://i.postimg.cc/J7K23vc0/flats.png", SHOES, null, null, null, null))
-        clothService.save(createCloth(HEELS, "https://i.postimg.cc/bND9GBmK/heels.png", SHOES, null, null, null, null))
-        clothService.save(createCloth(LOAFERS, "https://i.postimg.cc/2SFGmXjh/loafers.png", SHOES, null, null, null, null))
-        clothService.save(createCloth(SLIPPERS, "https://i.postimg.cc/nc35YgxT/slippers.png", SHOES, null, null, null, null))
-        clothService.save(createCloth(LEATHER_BOOTS, "https://i.postimg.cc/tgBYXXGW/leather-boots.png", SHOES, null, null, null, null))
-        clothService.save(createCloth(FUR_BOOTS, "https://i.postimg.cc/YCpnVFsH/fur-boots.png", SHOES, null, null, null, null))
-        clothService.save(createCloth(RAIN_BOOTS, "https://i.postimg.cc/jSZgrjpJ/rain-boots.png", SHOES, null, null, null, null))
-        clothService.save(createCloth(SANDALS, "https://i.postimg.cc/3R7dCKwn/sandals.png", SHOES, null, null, null, null))
-        clothService.save(createCloth(OXFORDS, "https://i.postimg.cc/DzFbQYyx/oxfords.png", SHOES, null, null, null, null))
-        clothService.save(createCloth(HIKING_SHOES, "https://i.postimg.cc/4xwh5Q7Z/hiking-shoes.png", SHOES, null, null, null, null))
-        clothService.save(createCloth(ANKLE_BOOTS, "https://i.postimg.cc/Xq8VbQ0Y/ankle-boots.png", SHOES, null, null, null, null))
+        clothService.save(create(SNEAKERS, "https://i.postimg.cc/1zkQQTYs/sneakers.png", SHOES, null, null, null, null))
+        clothService.save(create(ATHLETIC_SHOES, "https://i.postimg.cc/Bbg92vZn/athletic-shoes.png", SHOES, null, null, null, null))
+        clothService.save(create(FLATS, "https://i.postimg.cc/J7K23vc0/flats.png", SHOES, null, null, null, null))
+        clothService.save(create(HEELS, "https://i.postimg.cc/bND9GBmK/heels.png", SHOES, null, null, null, null))
+        clothService.save(create(LOAFERS, "https://i.postimg.cc/2SFGmXjh/loafers.png", SHOES, null, null, null, null))
+        clothService.save(create(SLIPPERS, "https://i.postimg.cc/nc35YgxT/slippers.png", SHOES, null, null, null, null))
+        clothService.save(create(LEATHER_BOOTS, "https://i.postimg.cc/tgBYXXGW/leather-boots.png", SHOES, null, null, null, null))
+        clothService.save(create(FUR_BOOTS, "https://i.postimg.cc/YCpnVFsH/fur-boots.png", SHOES, null, null, null, null))
+        clothService.save(create(RAIN_BOOTS, "https://i.postimg.cc/jSZgrjpJ/rain-boots.png", SHOES, null, null, null, null))
+        clothService.save(create(SANDALS, "https://i.postimg.cc/3R7dCKwn/sandals.png", SHOES, null, null, null, null))
+        clothService.save(create(OXFORDS, "https://i.postimg.cc/DzFbQYyx/oxfords.png", SHOES, null, null, null, null))
+        clothService.save(create(HIKING_SHOES, "https://i.postimg.cc/4xwh5Q7Z/hiking-shoes.png", SHOES, null, null, null, null))
+        clothService.save(create(ANKLE_BOOTS, "https://i.postimg.cc/Xq8VbQ0Y/ankle-boots.png", SHOES, null, null, null, null))
     }
 }

--- a/src/test/java/com/team04/back/domain/review/review/controller/ReviewControllerTest.kt
+++ b/src/test/java/com/team04/back/domain/review/review/controller/ReviewControllerTest.kt
@@ -290,10 +290,11 @@ class ReviewControllerTest {
             for (i in 0 until recommendedClothList.size) {
                 val cloth = recommendedClothList[i]
                 resultActions
-                    .andExpect(MockMvcResultMatchers.jsonPath("$.recommendedClothList[${i}].id").value(cloth.id))
-                    .andExpect(MockMvcResultMatchers.jsonPath("$.recommendedClothList[${i}].clothName").value(cloth.clothName))
-                    .andExpect(MockMvcResultMatchers.jsonPath("$.recommendedClothList[${i}].category").value(cloth.category))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.recommendedClothList[${i}].clothName").value(cloth.clothName.name))
                     .andExpect(MockMvcResultMatchers.jsonPath("$.recommendedClothList[${i}].imageUrl").value(cloth.imageUrl))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.recommendedClothList[${i}].category").value(cloth.category.name))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.recommendedClothList[${i}].style").value(cloth.style?.name))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.recommendedClothList[${i}].material").value(cloth.material?.name))
             }
         }
     }
@@ -497,48 +498,9 @@ class ReviewControllerTest {
     }
 
     @Test
-    @DisplayName("리뷰 작성 - inValid email")
-    @Throws(Exception::class)
-    fun t6_1() {
-        val resultActions = mvc
-            .perform(
-                MockMvcRequestBuilders.post("/api/v1/reviews")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(
-                        """
-                                        {
-                                            "email": "invalid-email",
-                                            "password": "1234",
-                                            "title": "Test Review",
-                                            "sentence": "This is a test review.",
-                                            "imageUrl": "https://example.com/image.jpg",
-                                            "tagString": "#test#review",
-                                            "countryCode": "KR",
-                                            "cityName": "Seoul",
-                                            "date": "2025-01-01"
-                                        }
-                                        """.trimIndent()
-                    )
-            ).andDo(MockMvcResultHandlers.print())
-
-        resultActions
-            .andExpect(MockMvcResultMatchers.handler().handlerType(ReviewController::class.java))
-            .andExpect(MockMvcResultMatchers.handler().methodName("createReview"))
-            .andExpect(MockMvcResultMatchers.status().isBadRequest)
-            .andExpect(MockMvcResultMatchers.jsonPath("$.resultCode").value("400-1"))
-            .andExpect(
-                MockMvcResultMatchers.jsonPath("$.msg").value(
-                    """
-                        email-Email-must be a well-formed email address
-                        """.trimIndent()
-                )
-            )
-    }
-
-    @Test
     @DisplayName("리뷰 작성 - inValid title")
     @Throws(Exception::class)
-    fun t6_2() {
+    fun t6_1() {
         val resultActions = mvc
             .perform(
                 MockMvcRequestBuilders.post("/api/v1/reviews")
@@ -578,7 +540,7 @@ class ReviewControllerTest {
     @Test
     @DisplayName("리뷰 작성 - inValid date")
     @Throws(Exception::class)
-    fun t6_3() {
+    fun t6_2() {
         val resultActions = mvc
             .perform(
                 MockMvcRequestBuilders.post("/api/v1/reviews")

--- a/src/test/java/com/team04/back/domain/review/review/service/ReviewServiceTest.kt
+++ b/src/test/java/com/team04/back/domain/review/review/service/ReviewServiceTest.kt
@@ -62,7 +62,7 @@ class ReviewServiceTest {
 
     // 테스트용 Review 실제 엔티티를 만들고, 상위 클래스까지 탐색해 id를 리플렉션으로 주입한다.
     private fun createReviewWithId(id: Int = 1): Review {
-        val review = Review("test@email.com", "password", "제목", "내용", "태그", "image_url", weatherInfo)
+        val review = Review(null, "test@email.com", "password", "제목", "내용", "태그", "image_url", weatherInfo)
         setPrivateField(review, "id", id)
         return review
     }
@@ -130,7 +130,7 @@ class ReviewServiceTest {
         // When
         val result = reviewService.createReview(
             "test@email.com", "password", "image_url",
-            "제목", "내용", "태그", weatherInfo, listOf(clothItem)
+            "제목", "내용", "태그", weatherInfo = weatherInfo, clothList = listOf(clothItem)
         )
 
         // Then
@@ -161,7 +161,7 @@ class ReviewServiceTest {
         assertThatThrownBy {
             reviewService.createReview(
                 "test@email.com", "password", "image_url",
-                "제목", "내용", "태그", weatherInfo, listOf(clothItem)
+                "제목", "내용", "태그", weatherInfo = weatherInfo, clothList = listOf(clothItem)
             )
         }.isInstanceOf(ServiceException::class.java)
             .hasMessageContaining("옷 정보를 찾을 수 없습니다.")
@@ -202,7 +202,7 @@ class ReviewServiceTest {
 
         // When
         val modifiedReview = reviewService.modifyReview(
-            review, "새 제목", "새 내용", null, null, weatherInfo, newClothItems
+            review, "새 제목", "새 내용", null, null, weatherInfo = weatherInfo, clothList = newClothItems
         )
 
         // Then
@@ -245,7 +245,7 @@ class ReviewServiceTest {
 
         // When
         reviewService.modifyReview(
-            review, "새 제목", "새 내용", null, null, weatherInfo, duplicateClothItems
+            review, "새 제목", "새 내용", null, null, weatherInfo = weatherInfo, clothList = duplicateClothItems
         )
 
         // Then
@@ -278,7 +278,7 @@ class ReviewServiceTest {
 
         // When
         reviewService.modifyReview(
-            review, "새 제목", "새 내용", null, null, weatherInfo, newClothItems
+            review, "새 제목", "새 내용", null, null, weatherInfo = weatherInfo, clothList = newClothItems
         )
 
         // Then
@@ -296,7 +296,7 @@ class ReviewServiceTest {
 
         // When
         val modifiedReview = reviewService.modifyReview(
-            review, "새 제목", "새 내용", null, null, weatherInfo, null
+            review, "새 제목", "새 내용", null, null, weatherInfo = weatherInfo, clothList = null
         )
 
         // Then

--- a/src/test/java/com/team04/back/domain/review/review/service/ReviewServiceTest.kt
+++ b/src/test/java/com/team04/back/domain/review/review/service/ReviewServiceTest.kt
@@ -129,8 +129,9 @@ class ReviewServiceTest {
 
         // When
         val result = reviewService.createReview(
-            "test@email.com", "password", "image_url",
-            "제목", "내용", "태그", weatherInfo = weatherInfo, clothList = listOf(clothItem)
+            email = "test@email.com", password = "password", imageUrl = "image_url",
+            title = "제목", sentence = "내용", tagString = "태그",
+            weatherInfo = weatherInfo, clothList = listOf(clothItem)
         )
 
         // Then
@@ -160,8 +161,9 @@ class ReviewServiceTest {
         // When & Then
         assertThatThrownBy {
             reviewService.createReview(
-                "test@email.com", "password", "image_url",
-                "제목", "내용", "태그", weatherInfo = weatherInfo, clothList = listOf(clothItem)
+                email = "test@email.com", password = "password", imageUrl = "image_url",
+                title = "제목", sentence = "내용", tagString = "태그",
+                weatherInfo = weatherInfo, clothList = listOf(clothItem)
             )
         }.isInstanceOf(ServiceException::class.java)
             .hasMessageContaining("옷 정보를 찾을 수 없습니다.")

--- a/src/test/java/com/team04/back/global/initData/TestInitData.kt
+++ b/src/test/java/com/team04/back/global/initData/TestInitData.kt
@@ -58,8 +58,8 @@ class TestInitData(
             "서울 여름 진짜 장난 아니네요;;",
             "요즘 서울 진짜 미쳤어요... 햇빛이 너무 따갑고, 낮엔 밖에 나가면 숨이 턱턱 막혀요. 아침저녁은 그나마 나은데 낮 기온은 거의 37도 가까이 올라가네요. 에어컨 없으면 진짜 버티기 힘듭니다 ㅠㅠ",
             "#한국여름#폭염주의",
-            weatherInfo1,
-            listOf(
+            weatherInfo = weatherInfo1,
+            clothList = listOf(
                 ClothItemReqBody(
                     clothName = ClothName.FUNCTIONAL_T_SHIRT,
                     category = Category.TOP,
@@ -93,8 +93,8 @@ class TestInitData(
             "삿포로는 진짜 눈나라가 맞아요",
             "삿포로의 겨울은 진짜 말 그대로 눈의 도시예요. 하루에도 몇 번씩 폭설이 내리고, 도로에 눈이 수북히 쌓여요. 체감 온도는 -15도까지도 떨어지고... 그래도 하얀 세상이 너무 예쁘고, 눈 오는 날 산책하는 재미도 있어요. 다만 옷 정말 단단히 입어야 합니다!",
             "#일본#삿포로#겨울#눈폭탄",
-            weatherInfo2,
-            listOf(
+            weatherInfo = weatherInfo2,
+            clothList = listOf(
                 ClothItemReqBody(
                     clothName = ClothName.COAT,
                     category = Category.TOP,
@@ -128,8 +128,8 @@ class TestInitData(
             "파리 여름밤 산책은 무조건이에요",
             "파리에 처음 왔는데 여름 날씨가 너무 좋아요. 낮에는 약간 덥긴 한데 그늘에 들어가면 시원하고, 밤에는 선선해서 산책하기 딱이에요. 센 강 주변이나 에펠탑 근처 돌아다니다 보면 기분이 정말 좋아져요. 덕분에 하루에 만 보 넘게 걷고 있어요 :)",
             "#파리#유럽여행#여름날씨#산책",
-            weatherInfo3,
-            listOf(
+            weatherInfo = weatherInfo3,
+            clothList = listOf(
                 ClothItemReqBody(
                     clothName = ClothName.T_SHIRT,
                     category = Category.TOP,
@@ -165,8 +165,8 @@ class TestInitData(
             "런던은 정말 자주 비가 오네요... 우산 필수입니다 ☔",
             "런던 가을비는 정말 자주 오는 편이네요. 하루에도 몇 번씩 비가 왔다 그쳤다 하고, 흐린 날이 많아요. 덕분에 분위기는 정말 좋지만, 외출할 때마다 우산은 필수예요. 현지 사람들은 그냥 맞고 다니던데... 전 그건 아직 무리네요 ㅎㅎ",
             "#런던#가을비#우산#영국날씨",
-            weatherInfo4,
-            listOf(
+            weatherInfo = weatherInfo4,
+            clothList = listOf(
                 ClothItemReqBody(
                     clothName = ClothName.COAT,
                     category = Category.TOP,

--- a/src/test/java/com/team04/back/global/initData/TestInitData.kt
+++ b/src/test/java/com/team04/back/global/initData/TestInitData.kt
@@ -1,9 +1,15 @@
 package com.team04.back.global.initData
 
+import com.team04.back.domain.cloth.cloth.entity.ClothInfo.Companion.create
 import com.team04.back.domain.cloth.cloth.enums.Category
+import com.team04.back.domain.cloth.cloth.enums.Category.*
 import com.team04.back.domain.cloth.cloth.enums.ClothName
+import com.team04.back.domain.cloth.cloth.enums.ClothName.*
 import com.team04.back.domain.cloth.cloth.enums.Material
+import com.team04.back.domain.cloth.cloth.enums.Material.*
 import com.team04.back.domain.cloth.cloth.enums.Style
+import com.team04.back.domain.cloth.cloth.enums.Style.*
+import com.team04.back.domain.cloth.cloth.service.ClothService
 import com.team04.back.domain.review.review.dto.ClothItemReqBody
 import com.team04.back.domain.review.review.service.ReviewService
 import com.team04.back.domain.weather.weather.entity.WeatherInfo
@@ -22,7 +28,8 @@ import java.time.LocalDate
 @TestConfiguration
 class TestInitData(
     private val reviewService: ReviewService,
-    private val weatherService: WeatherService
+    private val weatherService: WeatherService,
+    private val clothService: ClothService
 ) {
     @Autowired
     @Lazy
@@ -37,6 +44,133 @@ class TestInitData(
 
     @Transactional
     fun work1() {
+//        if (clothService.count() > 0) return
+
+        // === ClothInfo Style별 기본 데이터 ===
+        // CASUAL_DAILY - Cold
+        clothService.save(create(SWEATER, "https://i.postimg.cc/vZvNvYP5/cold-shirts.png", TOP, CASUAL_DAILY, WOOL, -10.0, 9.9)) // "cold_wool_warm_sweater"
+        clothService.save(create(CARGO_PANTS, "https://i.postimg.cc/vmNXPc5x/cold-pants.png", BOTTOM, CASUAL_DAILY, WOOL, -10.0, 9.9)) // "cold_wool_warm_pants"
+        clothService.save(create(LEATHER_BOOTS, "https://i.postimg.cc/65Xc1s4c/cold-shoes.png", SHOES, CASUAL_DAILY, LEATHER, -10.0, 9.9)) // "cold_leather_winter_boots"
+
+        // CASUAL_DAILY - Warm
+        clothService.save(create(DENIM_JACKET, "https://i.postimg.cc/sgfcspcZ/warm-shirts.png", TOP, CASUAL_DAILY, DENIM, 10.0, 20.0)) // "warm_denim_light_jacket"
+        clothService.save(create(JEANS, "https://i.postimg.cc/HLV97dFY/warm-pants.png", BOTTOM, CASUAL_DAILY, DENIM, 10.0, 20.0)) // "warm_denim_jeans"
+        clothService.save(create(SNEAKERS, "https://i.postimg.cc/SRp658RR/warm-shoes.png", SHOES, CASUAL_DAILY, null, 10.0, 20.0)) // "warm_canvas_sneakers"
+
+        // CASUAL_DAILY - Hot
+        clothService.save(create(T_SHIRT, "https://i.postimg.cc/h49bmCZd/hot-shirts.png", TOP, CASUAL_DAILY, COTTON, 20.1, 50.0)) // "hot_cotton_t_shirt"
+        clothService.save(create(SHORTS, "https://i.postimg.cc/FsNbVjwn/hot-pant.png", BOTTOM, CASUAL_DAILY, COTTON, 20.1, 50.0)) // "hot_cotton_shorts"
+        clothService.save(create(SANDALS, "https://i.postimg.cc/63CRd3cX/hot-shoes.png", SHOES, CASUAL_DAILY, null, 20.1, 50.0)) // "hot_synthetic_sandals"
+
+        // FORMAL_OFFICE - Cold
+        clothService.save(create(SWEATER,"https://i.postimg.cc/1XPFMQ7N/cold-shirts.png", TOP, FORMAL_OFFICE, WOOL, -10.0, 9.9)) // "cold_wool_sweater"
+        clothService.save(create(JEANS, "https://i.postimg.cc/DwmXx565/cold-pants.png", BOTTOM, FORMAL_OFFICE, WOOL, -10.0, 9.9)) // "cold_wool_dress_pants"
+        clothService.save(create(LEATHER_BOOTS, "https://i.postimg.cc/Dwt8Bh8y/cold-shoes.png", SHOES, FORMAL_OFFICE, LEATHER, -10.0, 9.9)) // "cold_leather_boots"
+
+        // FORMAL_OFFICE - Warm
+        clothService.save(create(BLAZER, "https://i.postimg.cc/fLskQvcG/warm-shirts.png", TOP, FORMAL_OFFICE, WOOL, 10.0, 20.0)) // "warm_blend_blazer"
+        clothService.save(create(CHINOS, "https://i.postimg.cc/J06hJVf8/warm-pants.png", BOTTOM, FORMAL_OFFICE, COTTON, 10.0, 20.0)) // "warm_cotton_chinos"
+        clothService.save(create(OXFORDS, "https://i.postimg.cc/9F00209Q/warm-shoes.png", SHOES, FORMAL_OFFICE, LEATHER, 10.0, 20.0)) // "warm_leather_oxfords"
+
+        // FORMAL_OFFICE - Hot
+        clothService.save(create(DRESS_SHIRT, "https://i.postimg.cc/MGSznpnR/hot-shirts.png", TOP, FORMAL_OFFICE, COTTON, 20.1, 50.0)) // "hot_cotton_dress_shirt"
+        clothService.save(create(SLACKS, "https://i.postimg.cc/wBQgLYNr/hot-pants.png", BOTTOM, FORMAL_OFFICE, POLYESTER, 20.1, 50.0)) // "hot_polyester_slacks"
+        clothService.save(create(LOAFERS, "https://i.postimg.cc/6qm9qVZ5/hot-shoes.png", SHOES, FORMAL_OFFICE, LEATHER, 20.1, 50.0)) // "hot_leather_loafers"
+
+        // OUTDOOR - Cold
+        clothService.save(create(PADDING, "https://i.postimg.cc/sxvrkBLF/cold-shirts.png", TOP, OUTDOOR, WOOL, -10.0, 9.9)) // "cold_wool_thermal_jacket"
+        clothService.save(create(SKI_PANTS, "https://i.postimg.cc/nc9xTD7B/cold-pants.png", BOTTOM, OUTDOOR, WOOL, -10.0, 9.9)) // "cold_wool_thermal_pants"
+        clothService.save(create(HIKING_SHOES, "https://i.postimg.cc/cLQSGGFJ/cold-shoes.png", SHOES, OUTDOOR, LEATHER, -10.0, 9.9)) // "cold_leather_hiking_boots"
+
+        // OUTDOOR - Warm
+        clothService.save(create(WINDBREAKER, "https://i.postimg.cc/nVjVSgfX/warm-shirts.png", TOP, OUTDOOR, NYLON, 10.0, 20.0)) // "warm_nylon_windbreaker"
+        clothService.save(create(CARGO_PANTS, "https://i.postimg.cc/rzXPfKXN/warm-pants.png", BOTTOM, OUTDOOR, COTTON, 10.0, 20.0)) // "warm_cotton_cargo_pants"
+        clothService.save(create(SNEAKERS, "https://i.postimg.cc/8k2p24Tt/warm-shoes.png", SHOES, OUTDOOR, null, 10.0, 20.0)) // "warm_mesh_trail_sneakers"
+
+        // OUTDOOR - Hot
+        clothService.save(create(FUNCTIONAL_T_SHIRT, "https://i.postimg.cc/2yqsHsqr/hot-shirts.png", TOP, OUTDOOR, POLYESTER, 20.1, 50.0)) // "hot_polyester_moisture_wicking_shirt"
+        clothService.save(create(SHORTS, "https://i.postimg.cc/0yGLHdNM/hot-pants.png", BOTTOM, OUTDOOR, POLYESTER, 20.1, 50.0)) // "hot_polyester_shorts"
+        clothService.save(create(SANDALS, "https://i.postimg.cc/vBKj600j/hot-shoes.png", SHOES, OUTDOOR, null, 20.1, 50.0)) // "hot_synthetic_sandals"
+
+        // DATE_LOOK - Cold
+        clothService.save(create(SWEATER, "https://i.postimg.cc/dtcFH09f/cold-shirts.png", TOP, DATE_LOOK, WOOL, -10.0, 9.9)) // "cold_wool_knit_sweater"
+        clothService.save(create(CORDUROY_PANTS, "https://i.postimg.cc/9QJjQYj3/cold-pants.png", BOTTOM, DATE_LOOK, CORDUROY, -10.0, 9.9)) // "cold_corduroy_pants"
+        clothService.save(create(ANKLE_BOOTS, "https://i.postimg.cc/FKzXdk9Y/cold-shoes.png", SHOES, DATE_LOOK, LEATHER, -10.0, 9.9)) // "cold_leather_ankle_boots"
+
+        // DATE_LOOK - Warm
+        clothService.save(create(CARDIGAN, "https://i.postimg.cc/NMrhbh2Y/warm-shirts.png", TOP, DATE_LOOK, COTTON, 10.0, 20.0)) // "warm_cotton_cardigan"
+        clothService.save(create(JEANS, "https://i.postimg.cc/9X7VY9yT/warm-pants.png", BOTTOM, DATE_LOOK, DENIM, 10.0, 20.0)) // "warm_denim_slim_jeans"
+        clothService.save(create(FLATS, "https://i.postimg.cc/ryxXrkLN/warm-shoes.png", SHOES, DATE_LOOK, LEATHER, 10.0, 20.0)) // "warm_leather_ballet_flats"
+
+        // DATE_LOOK - Hot
+        clothService.save(create(BLOUSE, "https://i.postimg.cc/521x0tYz/hot-shirts.png", TOP, DATE_LOOK, POLYESTER, 20.1, 50.0)) // "hot_polyester_floral_blouse"
+        clothService.save(create(SKIRT, "https://i.postimg.cc/3NmTrM39/hot-pants.png", BOTTOM, DATE_LOOK, POLYESTER, 20.1, 50.0)) // "hot_polyester_skirt"
+        clothService.save(create(HEELS, "https://i.postimg.cc/XY8ny0dz/hot-shoes.png", SHOES, DATE_LOOK, LEATHER, 20.1, 50.0)) // "hot_leather_open_toe_heels"
+
+        // === ExtraCloth 저장 ===
+        clothService.save(create(HAT, "https://i.postimg.cc/DytgTxVq/hat.png", Category.EXTRA, null, null, null, null)) // weather = Weather.HEAT_WAVE
+        clothService.save(create(CAP, "https://i.postimg.cc/ZYDkrz34/cap.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(BEANIE, "https://i.postimg.cc/GhBWKgJY/beanie.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(SCARF, "https://i.postimg.cc/XXMQQL4c/scarf.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(GLOVES, "https://i.postimg.cc/T15tVFM3/gloves.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(BELT, "https://i.postimg.cc/R0srGk87/belt.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(BAG, "https://i.postimg.cc/Y9Z5B1tj/bag.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(BACKPACK, "https://i.postimg.cc/L6dcyByb/backpack.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(CROSSBODY_BAG, "https://i.postimg.cc/13sLSR10/crossbody-bag.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(SUNGLASSES, "https://i.postimg.cc/6QQg7H3y/sunglasses.png", Category.EXTRA, null, null, null, null))
+        clothService.save(create(UMBRELLA, "https://i.postimg.cc/PqFc1mpK/umbrella.png", Category.EXTRA, null, null, null, null)) // weather = Weather.MODERATE_RAIN, Weather.SNOW
+        clothService.save(create(MASK, "https://i.postimg.cc/9M6nnCB7/mask.png", Category.EXTRA, null, null, null, null)) // weather = Weather.MIST
+
+
+        // === ClothInfo ClothName별 기본 데이터 ===
+        // TOP
+        clothService.save(create(T_SHIRT, "https://i.postimg.cc/GhZ3xc7G/t-shirt.png", TOP, null, null, null, null))
+        clothService.save(create(SWEATSHIRT, "https://i.postimg.cc/d0qbjN96/sweatshirt.png", TOP, null, null, null, null))
+        clothService.save(create(HOODIE, "https://i.postimg.cc/QMHRz9RK/hoodie.png", TOP, null, null, null, null))
+        clothService.save(create(SHIRT, "https://i.postimg.cc/YqMTHy5H/shirt.png", TOP, null, null, null, null))
+        clothService.save(create(DRESS_SHIRT, "https://i.postimg.cc/NM6JJn1L/dress-shirt.png", TOP, null, null, null, null))
+        clothService.save(create(BLOUSE, "https://i.postimg.cc/VvVtDhMC/blouse.png", TOP, null, null, null, null))
+        clothService.save(create(SWEATER, "https://i.postimg.cc/tgjxSW12/sweater.png", TOP, null, null, null, null))
+        clothService.save(create(CARDIGAN, "https://i.postimg.cc/GhvYkXtH/cardigan.png", TOP, null, null, null, null))
+        clothService.save(create(COAT, "https://i.postimg.cc/g2NxDQWk/coat.png", TOP, null, null, null, null))
+        clothService.save(create(JACKET, "https://i.postimg.cc/8z1f1VGN/jacket.png", TOP, null, null, null, null))
+        clothService.save(create(LEATHER_JACKET, "https://i.postimg.cc/ncw8GGWf/leather-jacket.png", TOP, null, null, null, null))
+        clothService.save(create(DENIM_JACKET, "https://i.postimg.cc/k53pT1Fz/denim-jacket.png", TOP, null, null, null, null))
+        clothService.save(create(BLAZER, "https://i.postimg.cc/T1F9p1tF/blazer.png", TOP, null, null, null, null))
+        clothService.save(create(PADDING, "https://i.postimg.cc/qBSXctGZ/padding.png", TOP, null, null, null, null))
+        clothService.save(create(VEST, "https://i.postimg.cc/gjZhtDKt/vest.png", TOP, null, null, null, null))
+        clothService.save(create(WINDBREAKER, "https://i.postimg.cc/3JLhbTd6/jacket.png", TOP, null, null, null, null))
+        clothService.save(create(FUNCTIONAL_T_SHIRT, "https://i.postimg.cc/QMk1RZyL/functional-t-shirt.png", TOP, null, null, null, null))
+
+        // BOTTOM
+        clothService.save(create(JEANS, "https://i.postimg.cc/rwSjHTJT/jeans.png", BOTTOM, null, null, null, null))
+        clothService.save(create(SLACKS, "https://i.postimg.cc/bYDBRKKy/slacks.png", BOTTOM, null, null, null, null))
+        clothService.save(create(SHORTS, "https://i.postimg.cc/448Zqk3r/shorts.png", BOTTOM, null, null, null, null))
+        clothService.save(create(SKIRT, "https://i.postimg.cc/3wZYh9pq/skirt.png", BOTTOM, null, null, null, null))
+        clothService.save(create(JOGGER_PANTS, "https://i.postimg.cc/Hn9hcPWG/jogger-pants.png", BOTTOM, null, null, null, null))
+        clothService.save(create(TRACK_PANTS, "https://i.postimg.cc/vmdMVCbT/track-pants.png", BOTTOM, null, null, null, null))
+        clothService.save(create(LEGGINGS, "https://i.postimg.cc/3NkkWzFN/leggings.png", BOTTOM, null, null, null, null))
+        clothService.save(create(CARGO_PANTS, "https://i.postimg.cc/9f3sLZv8/cargo-pants.png", BOTTOM, null, null, null, null))
+        clothService.save(create(CORDUROY_PANTS, "https://i.postimg.cc/g2LfyNBL/corduroy-pants.png", BOTTOM, null, null, null, null))
+        clothService.save(create(CHINOS, "https://i.postimg.cc/R0QpG81h/chinos.png", BOTTOM, null, null, null, null))
+        clothService.save(create(SKI_PANTS, "https://i.postimg.cc/02y6NJXB/ski-pants.png", BOTTOM, null, null, null, null))
+
+        // SHOES
+        clothService.save(create(SNEAKERS, "https://i.postimg.cc/1zkQQTYs/sneakers.png", SHOES, null, null, null, null))
+        clothService.save(create(ATHLETIC_SHOES, "https://i.postimg.cc/Bbg92vZn/athletic-shoes.png", SHOES, null, null, null, null))
+        clothService.save(create(FLATS, "https://i.postimg.cc/J7K23vc0/flats.png", SHOES, null, null, null, null))
+        clothService.save(create(HEELS, "https://i.postimg.cc/bND9GBmK/heels.png", SHOES, null, null, null, null))
+        clothService.save(create(LOAFERS, "https://i.postimg.cc/2SFGmXjh/loafers.png", SHOES, null, null, null, null))
+        clothService.save(create(SLIPPERS, "https://i.postimg.cc/nc35YgxT/slippers.png", SHOES, null, null, null, null))
+        clothService.save(create(LEATHER_BOOTS, "https://i.postimg.cc/tgBYXXGW/leather-boots.png", SHOES, null, null, null, null))
+        clothService.save(create(FUR_BOOTS, "https://i.postimg.cc/YCpnVFsH/fur-boots.png", SHOES, null, null, null, null))
+        clothService.save(create(RAIN_BOOTS, "https://i.postimg.cc/jSZgrjpJ/rain-boots.png", SHOES, null, null, null, null))
+        clothService.save(create(SANDALS, "https://i.postimg.cc/3R7dCKwn/sandals.png", SHOES, null, null, null, null))
+        clothService.save(create(OXFORDS, "https://i.postimg.cc/DzFbQYyx/oxfords.png", SHOES, null, null, null, null))
+        clothService.save(create(HIKING_SHOES, "https://i.postimg.cc/4xwh5Q7Z/hiking-shoes.png", SHOES, null, null, null, null))
+        clothService.save(create(ANKLE_BOOTS, "https://i.postimg.cc/Xq8VbQ0Y/ankle-boots.png", SHOES, null, null, null, null))
+
+
         if (reviewService.count() > 0) return
 
         val weatherInfo1 = WeatherInfo(Weather.CLEAR_SKY, 7.0, 33.0, 37.0, 24.0, "서울", LocalDate.parse("2022-07-28"))

--- a/src/test/java/com/team04/back/global/initData/TestInitData.kt
+++ b/src/test/java/com/team04/back/global/initData/TestInitData.kt
@@ -52,12 +52,12 @@ class TestInitData(
         weatherService.save(weatherInfo4)
 
         reviewService.createReview(
-            "user1@test.com",
-            "1234",
-            "https://images.unsplash.com/photo-1658874761235-8d56cbd5da2d?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NHx8b290ZCUyMCVFQyU5NyVBQyVFQiVBNiU4NHxlbnwwfHwwfHx8MA%3D%3D",
-            "서울 여름 진짜 장난 아니네요;;",
-            "요즘 서울 진짜 미쳤어요... 햇빛이 너무 따갑고, 낮엔 밖에 나가면 숨이 턱턱 막혀요. 아침저녁은 그나마 나은데 낮 기온은 거의 37도 가까이 올라가네요. 에어컨 없으면 진짜 버티기 힘듭니다 ㅠㅠ",
-            "#한국여름#폭염주의",
+            email = "user1@test.com",
+            password = "1234",
+            imageUrl = "https://images.unsplash.com/photo-1658874761235-8d56cbd5da2d?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NHx8b290ZCUyMCVFQyU5NyVBQyVFQiVBNiU4NHxlbnwwfHwwfHx8MA%3D%3D",
+            title = "서울 여름 진짜 장난 아니네요;;",
+            sentence = "요즘 서울 진짜 미쳤어요... 햇빛이 너무 따갑고, 낮엔 밖에 나가면 숨이 턱턱 막혀요. 아침저녁은 그나마 나은데 낮 기온은 거의 37도 가까이 올라가네요. 에어컨 없으면 진짜 버티기 힘듭니다 ㅠㅠ",
+            tagString = "#한국여름#폭염주의",
             weatherInfo = weatherInfo1,
             clothList = listOf(
                 ClothItemReqBody(
@@ -87,12 +87,12 @@ class TestInitData(
             )
         )
         reviewService.createReview(
-            "user2@test.com",
-            "1234",
-            "https://images.unsplash.com/photo-1638385583463-e3d424c22916?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MjB8fCVFQyU5RCVCQyVFQiVCMyVCOCUyMCVFQyU4MiVCRiVFRCU4RiVBQyVFQiVBMSU5QyUyMCVFQyVCRCU5NCVFQiU5NCU5NHxlbnwwfHwwfHx8MA%3D%3D",
-            "삿포로는 진짜 눈나라가 맞아요",
-            "삿포로의 겨울은 진짜 말 그대로 눈의 도시예요. 하루에도 몇 번씩 폭설이 내리고, 도로에 눈이 수북히 쌓여요. 체감 온도는 -15도까지도 떨어지고... 그래도 하얀 세상이 너무 예쁘고, 눈 오는 날 산책하는 재미도 있어요. 다만 옷 정말 단단히 입어야 합니다!",
-            "#일본#삿포로#겨울#눈폭탄",
+            email = "user2@test.com",
+            password = "1234",
+            imageUrl = "https://images.unsplash.com/photo-1638385583463-e3d424c22916?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MjB8fCVFQyU5RCVCQyVFQiVCMyVCOCUyMCVFQyU4MiVCRiVFRCU4RiVBQyVFQiVBMSU5QyUyMCVFQyVCRCU5NCVFQiU5NCU5NHxlbnwwfHwwfHx8MA%3D%3D",
+            title = "삿포로는 진짜 눈나라가 맞아요",
+            sentence = "삿포로의 겨울은 진짜 말 그대로 눈의 도시예요. 하루에도 몇 번씩 폭설이 내리고, 도로에 눈이 수북히 쌓여요. 체감 온도는 -15도까지도 떨어지고... 그래도 하얀 세상이 너무 예쁘고, 눈 오는 날 산책하는 재미도 있어요. 다만 옷 정말 단단히 입어야 합니다!",
+            tagString = "#일본#삿포로#겨울#눈폭탄",
             weatherInfo = weatherInfo2,
             clothList = listOf(
                 ClothItemReqBody(
@@ -122,12 +122,12 @@ class TestInitData(
             )
         )
         reviewService.createReview(
-            "user3@test.com",
-            "1234",
-            "https://images.unsplash.com/photo-1569789496053-095f2d6e3b05?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8OTR8fCVFRCU4QyU4QyVFQiVBNiVBQyUyMCVFQyU4MiVCMCVFQyVCMSU4NXxlbnwwfHwwfHx8MA%3D%3D",
-            "파리 여름밤 산책은 무조건이에요",
-            "파리에 처음 왔는데 여름 날씨가 너무 좋아요. 낮에는 약간 덥긴 한데 그늘에 들어가면 시원하고, 밤에는 선선해서 산책하기 딱이에요. 센 강 주변이나 에펠탑 근처 돌아다니다 보면 기분이 정말 좋아져요. 덕분에 하루에 만 보 넘게 걷고 있어요 :)",
-            "#파리#유럽여행#여름날씨#산책",
+            email = "user3@test.com",
+            password = "1234",
+            imageUrl = "https://images.unsplash.com/photo-1569789496053-095f2d6e3b05?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8OTR8fCVFRCU4QyU4QyVFQiVBNiVBQyUyMCVFQyU4MiVCMCVFQyVCMSU4NXxlbnwwfHwwfHx8MA%3D%3D",
+            title = "파리 여름밤 산책은 무조건이에요",
+            sentence = "파리에 처음 왔는데 여름 날씨가 너무 좋아요. 낮에는 약간 덥긴 한데 그늘에 들어가면 시원하고, 밤에는 선선해서 산책하기 딱이에요. 센 강 주변이나 에펠탑 근처 돌아다니다 보면 기분이 정말 좋아져요. 덕분에 하루에 만 보 넘게 걷고 있어요 :)",
+            tagString = "#파리#유럽여행#여름날씨#산책",
             weatherInfo = weatherInfo3,
             clothList = listOf(
                 ClothItemReqBody(
@@ -159,12 +159,12 @@ class TestInitData(
             )
         )
         reviewService.createReview(
-            "user4@test.com",
-            "1234",
-            "https://images.unsplash.com/photo-1518090753814-263ac71fc863?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8M3x8JUVCJTlGJUIwJUVCJThEJTk4JTIwJUVDJTlBJUIwJUVDJTgyJUIwfGVufDB8fDB8fHww",
-            "런던은 정말 자주 비가 오네요... 우산 필수입니다 ☔",
-            "런던 가을비는 정말 자주 오는 편이네요. 하루에도 몇 번씩 비가 왔다 그쳤다 하고, 흐린 날이 많아요. 덕분에 분위기는 정말 좋지만, 외출할 때마다 우산은 필수예요. 현지 사람들은 그냥 맞고 다니던데... 전 그건 아직 무리네요 ㅎㅎ",
-            "#런던#가을비#우산#영국날씨",
+            email = "user4@test.com",
+            password = "1234",
+            imageUrl = "https://images.unsplash.com/photo-1518090753814-263ac71fc863?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8M3x8JUVCJTlGJUIwJUVCJThEJTk4JTIwJUVDJTlBJUIwJUVDJTgyJUIwfGVufDB8fDB8fHww",
+            title = "런던은 정말 자주 비가 오네요... 우산 필수입니다 ☔",
+            sentence = "런던 가을비는 정말 자주 오는 편이네요. 하루에도 몇 번씩 비가 왔다 그쳤다 하고, 흐린 날이 많아요. 덕분에 분위기는 정말 좋지만, 외출할 때마다 우산은 필수예요. 현지 사람들은 그냥 맞고 다니던데... 전 그건 아직 무리네요 ㅎㅎ",
+            tagString = "#런던#가을비#우산#영국날씨",
             weatherInfo = weatherInfo4,
             clothList = listOf(
                 ClothItemReqBody(


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

-

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

- 리뷰 작성/수정/삭제 로직을 user(회원)도 가능하도록 개선
- EXTRA 의류 더미데이터도 추가


## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #55 

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

- 리뷰 수정/삭제 로직은 인증/인가 부분 일단 주석처리 해놨습니다
- User 엔티티는 임의로 BaseEntity 상속받도록만 수정했습니다
- test 오류 해결했습니다. db 파일 지우고 다시 실행하시면 됩니다!
  

## ✅ 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 작성
- [ ] 문서/주석 추가 및 최신화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 회원/비회원 리뷰 작성 지원: 로그인 사용자는 계정, 게스트는 이메일/비밀번호(선택)로 작성 가능.
  - 권한 강화: 리뷰 작성자만 수정/삭제 가능.
  - 리뷰 응답 확장: userId 추가, email이 null일 수 있음; verifyPassword 요청 DTO 통합 및 유효성 적용.
  - 추천 의상 응답 개선: clothName/category가 문자열로 노출되고 style, material 필드 추가(항목 id는 제외).
  - 초기 데이터 확장: MASK 등 다수 의상 항목 추가 및 초기화 순서 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->